### PR TITLE
Rename Module Names to make them toggleable through commands

### DIFF
--- a/src/main/java/com/nnpg/glazed/modules/esp/BlockNotifier.java
+++ b/src/main/java/com/nnpg/glazed/modules/esp/BlockNotifier.java
@@ -3,7 +3,6 @@ package com.nnpg.glazed.modules.esp;
 import com.nnpg.glazed.GlazedAddon;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.ChunkDataEvent;
-import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.renderer.ShapeMode;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -12,14 +11,12 @@ import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.Block;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.s2c.common.DisconnectS2CPacket;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.chunk.WorldChunk;
 
 import java.io.IOException;
 import java.net.URI;
@@ -156,7 +153,7 @@ public class BlockNotifier extends Module {
     private int total_blocks_found = 0;
 
     public BlockNotifier() {
-        super(GlazedAddon.esp, "Block Notifier", "Notifies when specific blocks are detected with multiple notification options and visual ESP.");
+        super(GlazedAddon.esp, "block-notifier", "Notifies when specific blocks are detected with multiple notification options and visual ESP.");
     }
 
     @Override

--- a/src/main/java/com/nnpg/glazed/modules/esp/RegionMap.java
+++ b/src/main/java/com/nnpg/glazed/modules/esp/RegionMap.java
@@ -107,7 +107,7 @@ public class RegionMap extends Module {
     private final PlayerTracker playerTracker;
 
     public RegionMap() {
-        super(GlazedAddon.esp, "Region Map",
+        super(GlazedAddon.esp, "region-map",
                 "DonutSMP region map and shows you your location");
 
         this.mapData = new MapDataManager();

--- a/src/main/java/com/nnpg/glazed/modules/esp/SpawnerNotifier.java
+++ b/src/main/java/com/nnpg/glazed/modules/esp/SpawnerNotifier.java
@@ -3,11 +3,10 @@ package com.nnpg.glazed.modules.esp;
 import com.nnpg.glazed.GlazedAddon;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.ChunkDataEvent;
-import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.renderer.ShapeMode;
-import meteordevelopment.meteorclient.utils.render.MeteorToast;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.render.MeteorToast;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
@@ -19,7 +18,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.chunk.WorldChunk;
 
 import java.io.IOException;
 import java.net.URI;
@@ -27,7 +25,10 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class SpawnerNotifier extends Module {
@@ -160,7 +161,7 @@ public class SpawnerNotifier extends Module {
     private int total_spawners_found = 0;
 
     public SpawnerNotifier() {
-        super(GlazedAddon.esp, "Spawner Notifier", "Notifies when spawners are detected with multiple notification options and visual ESP");
+        super(GlazedAddon.esp, "spawner-notifier", "Notifies when spawners are detected with multiple notification options and visual ESP");
     }
 
     @Override

--- a/src/main/java/com/nnpg/glazed/modules/esp/VineESP.java
+++ b/src/main/java/com/nnpg/glazed/modules/esp/VineESP.java
@@ -131,7 +131,7 @@ public class VineESP extends Module {
     private ExecutorService threadPool;
 
     public VineESP() {
-        super(GlazedAddon.esp, "Vine ESP", "ESP for vines that touch the ground.");
+        super(GlazedAddon.esp, "vine-esp", "ESP for vines that touch the ground.");
     }
 
     @Override

--- a/src/main/java/com/nnpg/glazed/modules/main/ChestAndShulkerStealer.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/ChestAndShulkerStealer.java
@@ -28,7 +28,7 @@ public class ChestAndShulkerStealer extends Module {
     private int currentSlot = 0;
 
     public ChestAndShulkerStealer() {
-        super(GlazedAddon.CATEGORY, "Storage Stealer", "Steals items from chests and shulkers.");
+        super(GlazedAddon.CATEGORY, "storage-stealer", "Steals items from chests and shulkers.");
     }
     
     @Override

--- a/src/main/java/com/nnpg/glazed/modules/pvp/AutoInvTotem.java
+++ b/src/main/java/com/nnpg/glazed/modules/pvp/AutoInvTotem.java
@@ -1,11 +1,14 @@
 package com.nnpg.glazed.modules.pvp;
 
 import com.nnpg.glazed.GlazedAddon;
-import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
 import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
+import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
-import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.IntSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
@@ -83,7 +86,7 @@ public class AutoInvTotem extends Module {
     private boolean invAutoOpened = false;
 
     public AutoInvTotem() {
-        super(GlazedAddon.pvp, "Auto Inv Totem", "Automatically moves totems to offhand when inventory is opened after totem pop.");
+        super(GlazedAddon.pvp, "auto-inv-totem", "Automatically moves totems to offhand when inventory is opened after totem pop.");
     }
 
     @Override

--- a/src/main/java/com/nnpg/glazed/modules/pvp/SwordPlaceObsidian.java
+++ b/src/main/java/com/nnpg/glazed/modules/pvp/SwordPlaceObsidian.java
@@ -1,8 +1,8 @@
 package com.nnpg.glazed.modules.pvp;
 
 import com.nnpg.glazed.GlazedAddon;
-import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
@@ -11,7 +11,6 @@ import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
-import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 
 public class SwordPlaceObsidian extends Module {
@@ -20,7 +19,7 @@ public class SwordPlaceObsidian extends Module {
     private int previousSlot = -1;
 
     public SwordPlaceObsidian() {
-        super(GlazedAddon.pvp, "Sword Obi Place", "Right-click with sword to place obsidian, then switch back.");
+        super(GlazedAddon.pvp, "sword-obi-place", "Right-click with sword to place obsidian, then switch back.");
     }
 
     @EventHandler


### PR DESCRIPTION
My IDE also removed unused Import on those Modules
The Module names will look the same in the ClickGui because meteor converts something like "auto-inv-totem" to "Auto Inv Totem"