### PR TITLE
Remove the comments from my modules and commands

### DIFF
--- a/src/main/java/com/nnpg/glazed/commands/DeathPosCommand.java
+++ b/src/main/java/com/nnpg/glazed/commands/DeathPosCommand.java
@@ -8,13 +8,6 @@ import net.minecraft.core.GlobalPos;
 
 import java.util.Optional;
 
-/**
- * Prints where the server says you last died.
- *
- * The client is told the last death location in the login and respawn packets, the same value a
- * recovery compass points at, so this works after the fact as long as you have not died again
- * since.
- */
 public class DeathPosCommand extends Command {
     public DeathPosCommand() {
         super("deathpos", "Prints the last death location the server sent you, and copies it.");

--- a/src/main/java/com/nnpg/glazed/commands/RemoverTestCommand.java
+++ b/src/main/java/com/nnpg/glazed/commands/RemoverTestCommand.java
@@ -6,9 +6,6 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 
-/**
- * Runs the ah listing remover on its own, so it can be tested without waiting for a limit cooldown.
- */
 public class RemoverTestCommand extends Command {
     public RemoverTestCommand() {
         super("removertest", "Runs the Iron Ah Restocker listing remover once, then stops.");
@@ -24,7 +21,6 @@ public class RemoverTestCommand extends Command {
                 return SINGLE_SUCCESS;
             }
 
-            // the tick handler only runs while the module is active, so switch it on first
             if (!module.isActive()) module.toggle();
 
             module.startRemoverTest();

--- a/src/main/java/com/nnpg/glazed/modules/main/AHSell.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/AHSell.java
@@ -111,8 +111,6 @@ public class AHSell extends Module {
             return;
         }
 
-        // the whole sequence is driven from onTick now. doing it here meant the first slot change
-        // and its /ah sell went out in the same tick, before the server was ever told the slot changed
         currentSlot = 0;
         sold = 0;
         waited = 0;
@@ -167,10 +165,6 @@ public class AHSell extends Module {
             return;
         }
 
-        // client-side only. the ServerboundSetCarriedItem packet is not flushed until
-        // MultiPlayerGameMode.tick(), which runs after TickEvent.Pre, so we have to yield at
-        // least one tick before the command or the server sells whatever slot it still thinks
-        // is held
         VersionUtil.setSelectedSlot(mc.player, currentSlot);
         delayCounter = slotDelay.get();
         state = State.SEND;
@@ -186,7 +180,6 @@ public class AHSell extends Module {
             return;
         }
 
-        // re-check: the stack can be gone if the last sale actually consumed this slot
         ItemStack stack = mc.player.getInventory().getItem(currentSlot);
         if (stack.isEmpty()) {
             currentSlot++;
@@ -205,7 +198,6 @@ public class AHSell extends Module {
     }
 
     private void tickAwaitConfirm() {
-        // server dialog with Yes / No buttons
         if (GlazedSell.isDialogOpen()) {
             if (GlazedSell.clickDialogYes()) {
                 sold++;
@@ -219,9 +211,6 @@ public class AHSell extends Module {
         AbstractContainerMenu screenHandler = mc.player.containerMenu;
 
         if (screenHandler instanceof ChestMenu handler && handler.getRowCount() == 3) {
-            // was a shift-right-click (QUICK_MOVE, button 1) on the confirm slot, which menu
-            // plugins generally ignore. clickConfirm does a plain left click (PICKUP, button 0)
-            // and hunts for the button instead of assuming slot 15
             if (GlazedSell.clickConfirm(handler)) {
                 sold++;
                 if (notifications.get()) info("Sold item in hotbar slot " + currentSlot + ".");
@@ -231,7 +220,6 @@ public class AHSell extends Module {
             }
         }
 
-        // no confirm screen showed up. dont claim a sale that never happened, just move on
         if (++waited >= confirmTimeout.get()) {
             if (notifications.get()) warning("No confirm screen for slot " + currentSlot + ", skipping.");
             GlazedSell.close();
@@ -244,7 +232,6 @@ public class AHSell extends Module {
     private void onChatMessage(ReceiveMessageEvent event) {
         String msg = event.getMessage().getString();
 
-        // never react to our own chat output, it re-enters this handler
         if (msg.contains("[Meteor]")) return;
 
         if (msg.contains("You have too many listed items.")) {

--- a/src/main/java/com/nnpg/glazed/modules/main/AhShieldSeller.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/AhShieldSeller.java
@@ -33,14 +33,6 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Shield version of the ah restocker.
- *
- * Shields do not stack, so a slot is one shield and the whole inventory is one batch. Take a batch
- * out of the chest, read the cheapest listing, list the lot just under it, refill and repeat. When
- * a listing bounces back, or the server says there is no room left, it waits, pulls every unsold
- * shield back off the ah, and starts over.
- */
 public class AhShieldSeller extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgPrice = settings.createGroup("Price lookup");
@@ -425,7 +417,6 @@ public class AhShieldSeller extends Module {
             case PULL -> tickPull();
             case PULL_CLOSE -> tickPullClose();
             case COLLECT_WAIT -> {
-                // the wait itself is just the delay, this runs once it expires
                 state = State.COLLECT_SEND;
             }
             case COLLECT_SEND -> tickCollectSend();
@@ -441,10 +432,7 @@ public class AhShieldSeller extends Module {
         }
     }
 
-    // ---------------------------------------------------------------- batch start
-
     private void tickIdle() {
-        // a scheduled clear is due. no wait here, nothing bounced, we are just tidying up
         if (pendingCollect) {
             pendingCollect = false;
 
@@ -484,8 +472,6 @@ public class AhShieldSeller extends Module {
 
         return null;
     }
-
-    // ---------------------------------------------------------------- chest grab
 
     private void tickChestOpen() {
         BlockPos target = lookedAtChest();
@@ -530,10 +516,6 @@ public class AhShieldSeller extends Module {
         return mc.player.containerMenu instanceof ChestMenu menu ? menu : null;
     }
 
-    /**
-     * Shift-clicks shields out of the chest one at a time. Shields do not stack, so one click is
-     * one shield and a full inventory is exactly one batch.
-     */
     private void tickGrab() {
         ChestMenu menu = openChest();
 
@@ -543,7 +525,6 @@ public class AhShieldSeller extends Module {
         }
 
         if (firstEmptyPlayerSlot(menu) < 0) {
-            // inventory is full, that is the batch
             state = State.CHEST_CLOSE;
             return;
         }
@@ -603,8 +584,6 @@ public class AhShieldSeller extends Module {
 
         return -1;
     }
-
-    // ---------------------------------------------------------------- price lookup
 
     private void tickPriceSend() {
         mc.getConnection().sendCommand(priceCommand.get().trim());
@@ -746,8 +725,6 @@ public class AhShieldSeller extends Module {
         return (long) value;
     }
 
-    // ---------------------------------------------------------------- listing
-
     private void tickSellSelect() {
         if (currentSlot > 8) {
             if (hasItemInMainInventory()) {
@@ -817,8 +794,6 @@ public class AhShieldSeller extends Module {
     }
 
     private void tickSellVerify() {
-        // the shield count is what matters, not the exact stack. a bounced shield can come back
-        // with different durability or a banner, so components are deliberately ignored here
         if (countInInventory() >= countBeforeSale) {
             if (notifications.get()) info("A shield came back, the ah is full. Waiting %d minute(s) before collecting.", collectWaitMinutes.get());
             startCollectRun();
@@ -829,8 +804,6 @@ public class AhShieldSeller extends Module {
         delayCounter = jitter(gapDelay.get(), 0);
         state = State.SELL_GAP;
     }
-
-    // ---------------------------------------------------------------- hotbar top-up
 
     private void tickPullOpen() {
         if (mc.player.containerMenu != mc.player.inventoryMenu) {
@@ -893,9 +866,6 @@ public class AhShieldSeller extends Module {
         state = State.SELL_SELECT;
     }
 
-    // ---------------------------------------------------------------- collect back
-
-    /** A bounce means the ah is full. Wait, then take every unsold shield back. */
     private void startCollectRun() {
         lastCycleFailed = true;
         closeAnyMenu();
@@ -904,7 +874,6 @@ public class AhShieldSeller extends Module {
         stalled = 0;
         goneRetries = 0;
 
-        // collecting switched off: still sit out the wait, then go again at a lower price
         if (!collectListings.get()) {
             delayCounter = jitter(collectWaitMinutes.get() * 60 * 20, 20 * 20);
             state = State.COOLDOWN;
@@ -915,10 +884,6 @@ public class AhShieldSeller extends Module {
         state = State.COLLECT_WAIT;
     }
 
-    /**
-     * Whether a collect run is due now. OnlyWhenFull never schedules one here, it waits for a
-     * shield to bounce back or for the server to say the ah is full.
-     */
     private boolean collectDue() {
         if (!collectListings.get()) return false;
 
@@ -938,7 +903,6 @@ public class AhShieldSeller extends Module {
         state = State.COLLECT_OPEN_MINE;
     }
 
-    /** Click the chest in the ah menu, which is what opens your own listings. */
     private void tickCollectOpenMine() {
         ChestMenu menu = openChest();
 
@@ -986,7 +950,6 @@ public class AhShieldSeller extends Module {
 
         if (++waited >= priceTimeout.get()) {
             if (menu != null) {
-                // some servers reuse the window id, try clicking anyway
                 waited = 0;
                 state = State.COLLECT_CLICK;
                 return;
@@ -1011,7 +974,6 @@ public class AhShieldSeller extends Module {
             return;
         }
 
-        // stop if there is nowhere to put them
         if (firstEmptyPlayerSlot(menu) < 0) {
             if (notifications.get()) info("Inventory is full, stopping the collect run at %d.", collected);
             state = State.COLLECT_CLOSE;
@@ -1050,10 +1012,6 @@ public class AhShieldSeller extends Module {
         delayCounter = jitter(collectDelay.get(), 2);
     }
 
-    /**
-     * A shield sold while we were reaching for it. Shut the menu, sit out a minute, then restart
-     * the run from the /ah command instead of clicking into a menu the server has moved on from.
-     */
     private void startCollectRetry() {
         closeAnyMenu();
 
@@ -1070,7 +1028,6 @@ public class AhShieldSeller extends Module {
         delayCounter = jitter(goneRetryMinutes.get() * 60 * 20, 20 * 10);
         state = State.COLLECT_RETRY;
 
-        // worded so it matches neither gone-message nor limit-message, or the module answers itself
         if (notifications.get()) info("Pausing about %d minute(s), then trying the pickup again.", goneRetryMinutes.get());
     }
 
@@ -1086,12 +1043,9 @@ public class AhShieldSeller extends Module {
 
         if (notifications.get()) info("Collected %d %s back, refilling.", collected, itemName());
 
-        // straight back to a fresh batch: top the inventory up from the chest and start again
         delayCounter = jitter(cycleGap.get(), 5);
         state = State.COOLDOWN;
     }
-
-    // ---------------------------------------------------------------- shared
 
     private void endBatch(boolean failed) {
         lastCycleFailed = failed;
@@ -1115,7 +1069,6 @@ public class AhShieldSeller extends Module {
         if (mc.screen != null) mc.setScreen(null);
     }
 
-    /** Counts by item type only. Shield durability and banner patterns must not split the count. */
     private int countInInventory() {
         int total = 0;
         int size = mc.player.getInventory().getContainerSize();
@@ -1163,15 +1116,12 @@ public class AhShieldSeller extends Module {
     private void onChatMessage(ReceiveMessageEvent event) {
         if (!isActive()) return;
 
-        // our own chat output comes back through this handler, so never react to it
         if (handlingMessage) return;
 
         String msg = event.getMessage().getString();
         if (msg == null || msg.isEmpty()) return;
         if (msg.contains("[Meteor]")) return;
 
-        // a shield sold out from under the pickup. COLLECT_RETRY is left out on purpose: more of
-        // these arriving during the pause must not keep pushing the timer back
         if (inCollectPickup() && matchesGoneMessage(msg)) {
             handlingMessage = true;
             try {
@@ -1182,7 +1132,6 @@ public class AhShieldSeller extends Module {
             return;
         }
 
-        // already heading for a collect run, nothing left to trigger
         if (inCollectRun()) return;
 
         if (!matchesLimitMessage(msg)) return;
@@ -1202,7 +1151,6 @@ public class AhShieldSeller extends Module {
         EveryNCycles
     }
 
-    /** Only the states that actually click shields out of the ah listen for a gone message. */
     private boolean inCollectPickup() {
         return state == State.COLLECT_SEND || state == State.COLLECT_OPEN_MINE
             || state == State.COLLECT_MINE_WAIT || state == State.COLLECT_CLICK;
@@ -1213,7 +1161,6 @@ public class AhShieldSeller extends Module {
             || state == State.COLLECT_CLOSE || inCollectPickup();
     }
 
-    /** Matches "that was already bought" and its many wordings. */
     private boolean matchesGoneMessage(String msg) {
         try {
             return Pattern.compile(goneRegex.get(), Pattern.CASE_INSENSITIVE).matcher(msg).find();

--- a/src/main/java/com/nnpg/glazed/modules/main/AutoLeave.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/AutoLeave.java
@@ -22,20 +22,11 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-/**
- * Leaves the server the moment another player loads in.
- *
- * A tripwire, not a state machine: every tick it walks the loaded players, and the first one that
- * is not you, not whitelisted and not filtered out gets you disconnected. Leaving turns the module
- * off so it does not fight you while you are in the menus, and unless you say otherwise it saves
- * itself as enabled anyway, so it is armed again the next time you launch the game.
- */
 public class AutoLeave extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgFilter = settings.createGroup("Filter");
     private final SettingGroup sgArming = settings.createGroup("Arming");
 
-    // some freecam mods spawn a fake player under this name, same list PlayerDetection uses
     private static final Set<String> PERMANENT_WHITELIST = new HashSet<>(Arrays.asList(
         "FreeCamera"
     ));
@@ -235,7 +226,6 @@ public class AutoLeave extends Module {
         fuse = -1;
 
         if (mc.getConnection() == null) {
-            // nothing left to disconnect from, so do not sit here pretending to be armed
             warning("No connection to drop, turning off.");
             toggle();
             return;
@@ -250,7 +240,6 @@ public class AutoLeave extends Module {
     @EventHandler
     private void onGameLeft(GameLeftEvent event) {
         if (!disableOnLeave.get()) {
-            // still reset, or the next world starts with a stale fuse
             graceCounter = joinGrace.get();
             fuse = -1;
             leaving = false;
@@ -266,7 +255,6 @@ public class AutoLeave extends Module {
     @Override
     public CompoundTag toTag() {
         CompoundTag tag = super.toTag();
-        // leaving turns the module off, so without this it would come back disabled next launch
         if (tag != null && armOnStartup.get()) tag.putBoolean("active", true);
         return tag;
     }

--- a/src/main/java/com/nnpg/glazed/modules/main/AutoRaidAfk.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/AutoRaidAfk.java
@@ -33,15 +33,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
-/**
- * Sits out a raid for you.
- *
- * It refuses to start unless a raid is actually running, then it left clicks on its own whenever
- * something is within reach. The clicks are plain left clicks on an unrandomised interval spread:
- * it never turns your head, never picks a target and never waits for a mob to line up, so what it
- * hits is whatever you were already pointing at. When the raid ends it drinks an ominous bottle out
- * of your hotbar to pull the next one, and if there is no bottle down there it says so and stops.
- */
 public class AutoRaidAfk extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgClicking = settings.createGroup("Clicking");
@@ -268,7 +259,6 @@ public class AutoRaidAfk extends Module {
 
     @Override
     public void onDeactivate() {
-        // never leave the use key stuck down, or the game locked, whatever we were in the middle of
         releaseUse();
         releaseFreeze();
         state = State.WATCH;
@@ -379,7 +369,6 @@ public class AutoRaidAfk extends Module {
     }
 
     private void tickDrinkSwap() {
-        // give the slot change a couple of ticks to land before holding use
         drinkTicks++;
         if (drinkTicks < 3) return;
 
@@ -483,7 +472,6 @@ public class AutoRaidAfk extends Module {
         return false;
     }
 
-    /** True or false when the boss bars could be read, null when they could not. */
     private Boolean raidBarUp() {
         if (mc.gui == null) return null;
 
@@ -517,10 +505,6 @@ public class AutoRaidAfk extends Module {
         return read ? Boolean.FALSE : null;
     }
 
-    /**
-     * The boss bar map is private and its name is remapped at runtime, so it gets picked out by
-     * type instead of by name.
-     */
     private static List<Field> bossMapFields() {
         if (bossMapFields == null) {
             List<Field> found = new ArrayList<>();
@@ -552,13 +536,6 @@ public class AutoRaidAfk extends Module {
         nagCounter = 200;
     }
 
-    // ---------------------------------------------------------------- the freeze
-
-    /**
-     * Swallows every screen while the freeze is on. Meteor's own menu is deliberately let through,
-     * because with movement and Escape gone it is the only way left to turn this off, and the death
-     * and disconnect screens are let through because blocking either one strands you.
-     */
     @EventHandler
     private void onOpenScreen(OpenScreenEvent event) {
         if (!frozen) return;
@@ -574,10 +551,6 @@ public class AutoRaidAfk extends Module {
         event.setCancelled(true);
     }
 
-    /**
-     * Swaps the player's input for a bare ClientInput, whose tick() does nothing at all. That kills
-     * every movement key at the source instead of fighting them one at a time, every tick.
-     */
     private void applyFreeze() {
         if (!frozen) {
             lockYaw = mc.player.getYRot();
@@ -587,7 +560,6 @@ public class AutoRaidAfk extends Module {
             if (notifications.get()) info("Frozen. The Meteor menu still opens, turn this off to move again.");
         }
 
-        // respawning or changing dimension hands you a new player with a fresh input, so keep looking
         if (mc.player.input != blankInput) {
             blankInput = new ClientInput();
             mc.player.input = blankInput;
@@ -603,7 +575,6 @@ public class AutoRaidAfk extends Module {
         drainKeys();
     }
 
-    /** Hands back a fresh keyboard input rather than a stored one, since the player may have changed. */
     private void releaseFreeze() {
         if (!frozen) return;
 
@@ -614,7 +585,6 @@ public class AutoRaidAfk extends Module {
         if (notifications.get()) info("Unfrozen.");
     }
 
-    /** Presses queue up whether or not anything reads them, so empty the ones that would fire later. */
     private void drainKeys() {
         drain(mc.options.keyInventory);
         drain(mc.options.keyDrop);
@@ -627,7 +597,6 @@ public class AutoRaidAfk extends Module {
         for (KeyMapping slot : mc.options.keyHotbarSlots) drain(slot);
     }
 
-    /** Never call this on the use key. The bottle drink holds that one down on purpose. */
     private void drain(KeyMapping key) {
         while (key.consumeClick());
         key.setDown(false);

--- a/src/main/java/com/nnpg/glazed/modules/main/BoatSeller.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/BoatSeller.java
@@ -31,11 +31,6 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Pulls boats from /orders, finds the cheapest matching auction, undercuts it, and lists every
- * boat individually. Boats already in the inventory are always finished before another order is
- * opened, including after the auction listing limit is reached.
- */
 public class BoatSeller extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgOrders = settings.createGroup("Orders menu");
@@ -448,12 +443,8 @@ public class BoatSeller extends Module {
             return;
         }
 
-        // Price first so differently-priced listings can be reclaimed while the inventory still
-        // has room, before a fresh order fills it with boats.
         state = State.PRICE_SEND;
     }
-
-    // ---------------------------------------------------------------- orders
 
     private void tickOrdersSend() {
         markMenu();
@@ -630,8 +621,6 @@ public class BoatSeller extends Module {
         state = State.PRICE_SEND;
     }
 
-    // ---------------------------------------------------------------- price lookup
-
     private void tickPriceSend() {
         closeAnyMenu();
         mc.getConnection().sendCommand(resolvedPriceCommand());
@@ -675,8 +664,6 @@ public class BoatSeller extends Module {
             return;
         }
 
-        // Always inspect our listings. The collector only touches matching boats whose parsed
-        // price differs from listPrice, so listings already at the right price stay in the AH.
         collected = 0;
         state = State.COLLECT_SEND;
     }
@@ -750,8 +737,6 @@ public class BoatSeller extends Module {
 
         return (long) value;
     }
-
-    // ---------------------------------------------------------------- reclaim old-price listings
 
     private void tickCollectSend() {
         closeAnyMenu();
@@ -840,8 +825,6 @@ public class BoatSeller extends Module {
             return;
         }
 
-        // Someone may buy the listing between our scan and click. If the slot changed without a
-        // boat arriving, skip the stale entry and keep collecting the rest.
         if (collectSource < 0 || !ItemStack.matches(collectSnapshot, itemAt(menu, collectSource))) {
             collectSnapshot = ItemStack.EMPTY;
             waited = 0;
@@ -878,7 +861,6 @@ public class BoatSeller extends Module {
         state = State.ORDERS_SEND;
     }
 
-    /** A matching own listing whose price is not the current target, or -1. */
     private int findDifferentlyPricedBoat(ChestMenu menu) {
         Pattern pattern;
         try {
@@ -898,12 +880,8 @@ public class BoatSeller extends Module {
             if (price <= 0 && unpricedFallback < 0) unpricedFallback = slot;
         }
 
-        // On the first pass, an unpriced matching entry is safer to reclaim than leave stranded.
-        // Normal Donut listings expose a price, so this is only a compatibility fallback.
         return unpricedFallback;
     }
-
-    // ---------------------------------------------------------------- auction listing
 
     private void tickSellSelect() {
         if (currentSlot > 8) {
@@ -1020,8 +998,6 @@ public class BoatSeller extends Module {
                 return;
             }
 
-            // Preserve a full hotbar: park one item in the boat's main-inventory slot, use its
-            // hotbar position for every listing, then swap the original item back at the end.
             displacedMainSlot = source;
             displacedHotbarSlot = target;
             displacedHotbarItem = mc.player.getInventory().getItem(target).copy();
@@ -1050,8 +1026,6 @@ public class BoatSeller extends Module {
         delayCounter = delay(screenDelay, false);
         state = State.SELL_SELECT;
     }
-
-    // ---------------------------------------------------------------- helpers
 
     private String resolvedPriceCommand() {
         String override = priceCommand.get().trim();
@@ -1124,7 +1098,6 @@ public class BoatSeller extends Module {
         return -1;
     }
 
-    /** Restores the hotbar item temporarily displaced to make room for listings. */
     private void restoreDisplacedHotbarItem() {
         if (displacedMainSlot < 0 || displacedHotbarSlot < 0 || displacedHotbarItem.isEmpty()) return;
         if (mc.player == null || mc.gameMode == null) return;

--- a/src/main/java/com/nnpg/glazed/modules/main/ChestSeller.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/ChestSeller.java
@@ -22,10 +22,6 @@ import net.minecraft.world.phys.HitResult;
 
 import java.util.Random;
 
-/**
- * Repeatedly empties the chest under the crosshair into the player's inventory, transfers the
- * inventory into /sell, and presses the green sell button.
- */
 public class ChestSeller extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgTiming = settings.createGroup("Timing");

--- a/src/main/java/com/nnpg/glazed/modules/main/InvSell.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/InvSell.java
@@ -19,11 +19,6 @@ import net.minecraft.world.item.Items;
 
 import java.util.Random;
 
-/**
- * Sells the whole inventory through /ah sell. Works the hotbar the same way AHSell does, then
- * opens the inventory and pulls the next batch down into the empty hotbar, until nothing sellable
- * is left.
- */
 public class InvSell extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgTiming = settings.createGroup("Timing");
@@ -196,7 +191,6 @@ public class InvSell extends Module {
 
     @Override
     public void onDeactivate() {
-        // never leave the inventory hanging open because the module was switched off mid-refill
         closeInventoryScreen();
         state = State.SELECT;
         delayCounter = 0;
@@ -229,13 +223,11 @@ public class InvSell extends Module {
     }
 
     private void tickSelect() {
-        // hotbar exhausted, go pull the next batch down
         if (currentSlot > 8) {
             state = State.REFILL_OPEN;
             return;
         }
 
-        // the sell flow runs with no screen up, same as typing the command by hand
         if (isInventoryScreenOpen()) {
             closeInventoryScreen();
             delayCounter = jitter(screenDelay.get(), 1);
@@ -249,9 +241,6 @@ public class InvSell extends Module {
             return;
         }
 
-        // client-side only. the carried item packet is not flushed until MultiPlayerGameMode.tick(),
-        // which runs after TickEvent.Pre, so yield a tick before the command or the server sells
-        // whatever slot it still thinks is held
         VersionUtil.setSelectedSlot(mc.player, currentSlot);
         delayCounter = jitter(slotDelay.get(), 1);
         state = State.SEND;
@@ -309,9 +298,7 @@ public class InvSell extends Module {
         }
     }
 
-    /** Gets the inventory actually open before any slot gets clicked. */
     private void tickRefillOpen() {
-        // a swap only lands in the player's own inventory menu, so make sure a shop menu is gone
         if (mc.player.containerMenu != mc.player.inventoryMenu) {
             GlazedSell.close();
             delayCounter = jitter(screenDelay.get(), 1);
@@ -328,24 +315,17 @@ public class InvSell extends Module {
             return;
         }
 
-        // opening your own inventory sends nothing by itself, but it is what stops you sprinting
-        // and puts the client in the state the following slot clicks are supposed to come from
         mc.setScreen(new InventoryScreen(mc.player));
         delayCounter = jitter(screenDelay.get(), 1);
         state = State.REFILL;
     }
 
-    /**
-     * Moves one stack from the main inventory into a free hotbar slot. Runs once per refill-delay
-     * until the hotbar is stocked again, then closes up and restarts the hotbar pass.
-     */
     private void tickRefill() {
         if (mc.player.containerMenu != mc.player.inventoryMenu) {
             state = State.REFILL_OPEN;
             return;
         }
 
-        // something closed the screen under us, reopen before clicking anything
         if (openInventory.get() && !isInventoryScreenOpen()) {
             state = State.REFILL_OPEN;
             return;
@@ -354,7 +334,6 @@ public class InvSell extends Module {
         int source = firstSellable(InventoryMenu.INV_SLOT_START, InventoryMenu.INV_SLOT_END);
 
         if (source < 0) {
-            // nothing left upstairs. if the hotbar somehow refilled anyway, take another pass
             finishAfterClose = !hasSellableItem(0, 9);
             state = State.REFILL_CLOSE;
             return;
@@ -363,7 +342,6 @@ public class InvSell extends Module {
         int target = firstEmptyHotbarSlot();
 
         if (target < 0) {
-            // hotbar is stocked, go sell it before pulling anything else down
             finishAfterClose = false;
             state = State.REFILL_CLOSE;
             return;
@@ -371,12 +349,8 @@ public class InvSell extends Module {
 
         ItemStack before = mc.player.getInventory().getItem(source).copy();
 
-        // main inventory slots map 1:1 onto menu slots, and SWAP's button arg is the hotbar index,
-        // exactly like pressing 1-9 over a stack
         mc.gameMode.handleContainerInput(mc.player.inventoryMenu.containerId, source, target, ContainerInput.SWAP, mc.player);
 
-        // the swap is client-predicted, so this reads back immediately. if it did not take, stop
-        // rather than spinning on the same slot forever
         if (ItemStack.matches(before, mc.player.getInventory().getItem(source))) {
             if (++stalledRefills >= 3) {
                 if (notifications.get()) warning("Could not move items out of the inventory, stopping.");
@@ -419,10 +393,6 @@ public class InvSell extends Module {
         state = State.GAP;
     }
 
-    /**
-     * A listing that fails server side hands the item straight back. If we still hold as much of it
-     * as before the sale, nothing actually left, so stop rather than hammering the same item.
-     */
     private void tickVerify() {
         int after = countMatching(soldRef);
 
@@ -440,7 +410,6 @@ public class InvSell extends Module {
         state = State.GAP;
     }
 
-    /** Total count of everything in the inventory that matches ref, item and components alike. */
     private int countMatching(ItemStack ref) {
         if (ref.isEmpty()) return 0;
 
@@ -455,7 +424,6 @@ public class InvSell extends Module {
         return total;
     }
 
-    /** Spreads a delay by +/- timing-jitter percent, never below floor. */
     private int jitter(int ticks, int floor) {
         int pct = timingJitter.get();
         if (pct <= 0) return Math.max(floor, ticks);
@@ -468,7 +436,6 @@ public class InvSell extends Module {
         return mc.screen instanceof InventoryScreen;
     }
 
-    /** Closes it the way the key bind does, so the same ContainerClose the server expects goes out. */
     private void closeInventoryScreen() {
         if (mc.screen instanceof InventoryScreen screen) screen.onClose();
     }
@@ -484,7 +451,6 @@ public class InvSell extends Module {
     private void onChatMessage(ReceiveMessageEvent event) {
         String msg = event.getMessage().getString();
 
-        // never react to our own chat output, it re-enters this handler
         if (msg.contains("[Meteor]")) return;
 
         if (msg.contains("You have too many listed items.")) {
@@ -498,7 +464,6 @@ public class InvSell extends Module {
         return !enableFilter.get() || stack.is(filterItem.get());
     }
 
-    /** First inventory index in [from, to) holding something we want to sell, or -1. */
     private int firstSellable(int from, int to) {
         for (int slot = from; slot < to && slot < mc.player.getInventory().getContainerSize(); slot++) {
             if (shouldSell(mc.player.getInventory().getItem(slot))) return slot;

--- a/src/main/java/com/nnpg/glazed/modules/main/IronAhRestocker.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/IronAhRestocker.java
@@ -34,14 +34,6 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Restocks the auction house with single ingots.
- *
- * One cycle: read the cheapest per-unit price off the ah, take a full inventory of ingots out of
- * the chest you are looking at (one per slot), list every one of them at that price minus the
- * undercut, then go straight round again. The only thing that parks the module is the server
- * saying you have listed too many items.
- */
 public class IronAhRestocker extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgPrice = settings.createGroup("Price lookup");
@@ -464,10 +456,7 @@ public class IronAhRestocker extends Module {
         }
     }
 
-    // ---------------------------------------------------------------- cycle start
-
     private void tickIdle() {
-        // a limit cooldown just ended: clear the unsold listings before pricing anything new
         if (pendingRemoval) {
             pendingRemoval = false;
 
@@ -481,8 +470,6 @@ public class IronAhRestocker extends Module {
             }
         }
 
-        // A stack returned by the AH is stock, not one listing. Finish spreading and selling
-        // inventory stock before taking anything else from the source chest.
         if (hasAnyItemInInventory()) {
             currentSlot = 0;
             listed = 0;
@@ -496,7 +483,6 @@ public class IronAhRestocker extends Module {
         BlockPos target = lookedAtChest();
 
         if (requireChestLook.get() && target == null) {
-            // just wait, silently. looking away is how you pause this thing
             delayCounter = jitter(12, 4);
             return;
         }
@@ -510,7 +496,6 @@ public class IronAhRestocker extends Module {
         state = State.PRICE_SEND;
     }
 
-    /** The chest the crosshair is on, or null. */
     private BlockPos lookedAtChest() {
         if (!(mc.hitResult instanceof BlockHitResult hit)) return null;
         if (hit.getType() != HitResult.Type.BLOCK) return null;
@@ -522,8 +507,6 @@ public class IronAhRestocker extends Module {
 
         return null;
     }
-
-    // ---------------------------------------------------------------- price lookup
 
     private void tickPriceSend() {
         mc.getConnection().sendCommand(priceCommand.get().trim());
@@ -545,7 +528,6 @@ public class IronAhRestocker extends Module {
 
             long price = cheapest - undercut.get();
 
-            // a retry has to actually be cheaper than the number that just bounced
             if (lastCycleFailed && lastAttemptPrice > 0) {
                 price = Math.min(price, lastAttemptPrice - failUndercut.get());
             }
@@ -581,7 +563,6 @@ public class IronAhRestocker extends Module {
         state = hasAnyItemInInventory() ? State.SPREAD_OPEN : State.CHEST_OPEN;
     }
 
-    /** Cheapest per-unit price across the listings in the menu. */
     private long cheapestPerUnit(ChestMenu menu) {
         Pattern pattern;
 
@@ -602,11 +583,8 @@ public class IronAhRestocker extends Module {
             long price = parseListingPrice(stack, pattern);
             if (price <= 0) continue;
 
-            // a single-item listing divides by 1, so this is a no-op there and still correct
-            // for a stack priced as a whole
             long unit = perUnit.get() ? Math.max(1, price / Math.max(1, stack.getCount())) : price;
 
-            // the ah comes sorted by price, so the first listing is already the cheapest
             if (firstListingOnly.get()) return unit;
 
             if (best < 0 || unit < best) best = unit;
@@ -615,10 +593,6 @@ public class IronAhRestocker extends Module {
         return best;
     }
 
-    /**
-     * Reads the price off a listing. A line that actually says "price" or carries a $ wins, so a
-     * stack count or a seller name in the lore cannot be mistaken for the number.
-     */
     private long parseListingPrice(ItemStack stack, Pattern pattern) {
         List<String> lines = new ArrayList<>();
         lines.add(stack.getHoverName().getString());
@@ -636,7 +610,6 @@ public class IronAhRestocker extends Module {
             if (price > 0) return price;
         }
 
-        // nothing labelled, fall back to the first number anywhere in the tooltip
         for (String line : lines) {
             long price = matchPrice(line, pattern);
             if (price > 0) return price;
@@ -675,8 +648,6 @@ public class IronAhRestocker extends Module {
         return (long) value;
     }
 
-    // ---------------------------------------------------------------- chest grab
-
     private void tickChestOpen() {
         BlockPos target = lookedAtChest();
 
@@ -694,7 +665,6 @@ public class IronAhRestocker extends Module {
             return;
         }
 
-        // same call the right click makes, swing included
         mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, hit);
         mc.player.swing(InteractionHand.MAIN_HAND);
 
@@ -720,7 +690,6 @@ public class IronAhRestocker extends Module {
         return mc.player.containerMenu instanceof ChestMenu menu ? menu : null;
     }
 
-    /** Left click a stack of ingots in the chest to take it onto the cursor. */
     private void tickGrabPickup() {
         ChestMenu menu = openChest();
 
@@ -735,7 +704,6 @@ public class IronAhRestocker extends Module {
         }
 
         if (firstEmptyPlayerSlot(menu) < 0) {
-            // inventory already full of singles
             state = State.CHEST_CLOSE;
             return;
         }
@@ -765,7 +733,6 @@ public class IronAhRestocker extends Module {
         state = State.GRAB_PLACE;
     }
 
-    /** Right click an empty slot to drop exactly one off the cursor, the vanilla way. */
     private void tickGrabPlace() {
         ChestMenu menu = openChest();
 
@@ -775,7 +742,6 @@ public class IronAhRestocker extends Module {
         }
 
         if (mc.player.containerMenu.getCarried().isEmpty()) {
-            // cursor ran dry, grab another stack if there is more to place
             state = firstEmptyPlayerSlot(menu) < 0 ? State.CHEST_CLOSE : State.GRAB_PICKUP;
             return;
         }
@@ -792,7 +758,6 @@ public class IronAhRestocker extends Module {
         delayCounter = jitter(clickDelay.get(), 1);
     }
 
-    /** Put whatever is left on the cursor back where it came from. */
     private void tickGrabReturn() {
         ChestMenu menu = openChest();
 
@@ -816,7 +781,6 @@ public class IronAhRestocker extends Module {
         delayCounter = jitter(screenDelay.get(), 1);
 
         if (grabbed <= 0 && !hasAnyItemInInventory()) {
-            // nothing to restock, do not come straight back and re-run the ah command
             endCycleBackoff();
             return;
         }
@@ -827,7 +791,6 @@ public class IronAhRestocker extends Module {
         state = State.SPREAD_OPEN;
     }
 
-    /** First empty player-inventory slot of the open chest menu, in menu indices. */
     private int firstEmptyPlayerSlot(ChestMenu menu) {
         int containerSlots = menu.getRowCount() * 9;
 
@@ -838,9 +801,6 @@ public class IronAhRestocker extends Module {
         return -1;
     }
 
-    // ---------------------------------------------------------------- listing
-
-    /** Opens the real inventory before splitting any stack. */
     private void tickSpreadOpen() {
         if (mc.player.containerMenu != mc.player.inventoryMenu) {
             closeAnyMenu();
@@ -857,7 +817,6 @@ public class IronAhRestocker extends Module {
         state = State.SPREAD_PICKUP;
     }
 
-    /** Picks up one multi-ingot stack. Singles are deliberately ignored. */
     private void tickSpreadPickup() {
         if (mc.player.containerMenu != mc.player.inventoryMenu || !(mc.screen instanceof InventoryScreen)) {
             state = State.SPREAD_OPEN;
@@ -875,8 +834,6 @@ public class IronAhRestocker extends Module {
             return;
         }
 
-        // Keep the source slot empty while spreading. If the stack does not fit completely, the
-        // remainder goes back here and is never exposed to /ah sell.
         spreadSourceSlot = source;
         mc.gameMode.handleContainerInput(mc.player.inventoryMenu.containerId,
             inventoryMenuSlot(source), 0, ContainerInput.PICKUP, mc.player);
@@ -884,7 +841,6 @@ public class IronAhRestocker extends Module {
         state = State.SPREAD_PLACE;
     }
 
-    /** Right-clicks one ingot into each empty inventory slot. */
     private void tickSpreadPlace() {
         if (mc.player.containerMenu != mc.player.inventoryMenu || !(mc.screen instanceof InventoryScreen)) {
             returnSpreadCursor();
@@ -910,7 +866,6 @@ public class IronAhRestocker extends Module {
         delayCounter = jitter(clickDelay.get(), 1);
     }
 
-    /** Returns the unsplit remainder to its original slot. */
     private void tickSpreadReturn() {
         if (mc.player.containerMenu != mc.player.inventoryMenu) {
             state = State.SPREAD_OPEN;
@@ -933,14 +888,11 @@ public class IronAhRestocker extends Module {
 
     private void tickSellSelect() {
         if (currentSlot > 8) {
-            // the hotbar is the only place /ah sell can reach, so top it back up from below
             if (hasSingleInMainInventory()) {
                 state = State.PULL_OPEN;
                 return;
             }
 
-            // Selling the singles creates room. Use it to spread the next part of any retained
-            // stack, then make another singles-only pass.
             if (hasStackedItemInInventory()) {
                 if (freeInventorySlots() > 0) {
                     state = State.SPREAD_OPEN;
@@ -971,8 +923,6 @@ public class IronAhRestocker extends Module {
     private void tickSellSend() {
         ItemStack stack = mc.player.getInventory().getItem(currentSlot);
 
-        // Last-line safety: a stack can never reach the command even if another state changes
-        // inventory contents between selection and send.
         if (stack.isEmpty() || !stack.is(item.get()) || stack.getCount() != 1) {
             currentSlot++;
             state = State.SELL_SELECT;
@@ -1031,9 +981,6 @@ public class IronAhRestocker extends Module {
         state = State.SELL_GAP;
     }
 
-    // ---------------------------------------------------------------- hotbar top-up
-
-    /** Opens the inventory for real before any slot gets clicked, same as InvSell does. */
     private void tickPullOpen() {
         if (mc.player.containerMenu != mc.player.inventoryMenu) {
             closeAnyMenu();
@@ -1051,7 +998,6 @@ public class IronAhRestocker extends Module {
         state = State.PULL;
     }
 
-    /** Swaps ingots up into the empty hotbar slots, one click at a time, screen open throughout. */
     private void tickPull() {
         if (mc.player.containerMenu != mc.player.inventoryMenu) {
             state = State.PULL_OPEN;
@@ -1059,7 +1005,6 @@ public class IronAhRestocker extends Module {
         }
 
         if (!(mc.screen instanceof InventoryScreen)) {
-            // something closed it under us, reopen rather than clicking into nothing
             state = State.PULL_OPEN;
             return;
         }
@@ -1164,7 +1109,6 @@ public class IronAhRestocker extends Module {
         return -1;
     }
 
-    /** Player inventory index to its slot in InventoryMenu. */
     private int inventoryMenuSlot(int inventorySlot) {
         if (inventorySlot >= 0 && inventorySlot <= 8) {
             return InventoryMenu.USE_ROW_SLOT_START + inventorySlot;
@@ -1173,7 +1117,6 @@ public class IronAhRestocker extends Module {
         return inventorySlot;
     }
 
-    /** Never close the inventory with the unsplit remainder still attached to the cursor. */
     private void returnSpreadCursor() {
         if (mc.player == null || mc.gameMode == null) return;
         if (mc.player.containerMenu != mc.player.inventoryMenu) return;
@@ -1188,8 +1131,6 @@ public class IronAhRestocker extends Module {
         if (target >= 0) {
             ItemStack destination = mc.player.getInventory().getItem(target);
 
-            // The original slot should be empty. Merging into the same item is also safe; never
-            // swap the remainder with an unrelated item while recovering from a screen close.
             if (destination.isEmpty() || destination.is(item.get())) {
                 mc.gameMode.handleContainerInput(mc.player.inventoryMenu.containerId,
                     inventoryMenuSlot(target), 0, ContainerInput.PICKUP, mc.player);
@@ -1199,9 +1140,6 @@ public class IronAhRestocker extends Module {
         spreadSourceSlot = -1;
     }
 
-    // ---------------------------------------------------------------- listing remover
-
-    /** Entry point for .removertest, runs the remover on its own and stops afterwards. */
     public void startRemoverTest() {
         removerTestOnly = true;
         pendingRemoval = false;
@@ -1222,7 +1160,6 @@ public class IronAhRestocker extends Module {
         state = State.REMOVE_OPEN_MINE;
     }
 
-    /** Click the chest in the ah menu, which is what opens your own listings. */
     private void tickRemoveOpenMine() {
         ChestMenu menu = openChest();
 
@@ -1259,7 +1196,6 @@ public class IronAhRestocker extends Module {
         state = State.REMOVE_MINE_WAIT;
     }
 
-    /** Wait for the server to swap the menu for your listings one. */
     private void tickRemoveMineWait() {
         ChestMenu menu = openChest();
 
@@ -1270,7 +1206,6 @@ public class IronAhRestocker extends Module {
         }
 
         if (++waited >= priceTimeout.get()) {
-            // some servers reuse the same window id, so try clicking anyway rather than giving up
             if (menu != null) {
                 waited = 0;
                 state = State.REMOVE_CLICK;
@@ -1282,7 +1217,6 @@ public class IronAhRestocker extends Module {
         }
     }
 
-    /** Click one listing per remove-delay until they are gone. */
     private void tickRemoveClick() {
         ChestMenu menu = openChest();
 
@@ -1315,7 +1249,6 @@ public class IronAhRestocker extends Module {
         ItemStack before = menu.getSlot(target).getItem().copy();
         mc.gameMode.handleContainerInput(menu.containerId, target, 0, ContainerInput.PICKUP, mc.player);
 
-        // the menu only updates when the server answers, so watch for the slot going stale
         if (ItemStack.matches(before, menu.getSlot(target).getItem())) {
             if (++stalledRemovals >= 6) {
                 if (notifications.get()) warning("Listings are not clearing, stopping the removal pass.");
@@ -1330,10 +1263,6 @@ public class IronAhRestocker extends Module {
         delayCounter = jitter(removeDelay.get(), 2);
     }
 
-    /**
-     * A listing went while we were reaching for it. Sit out a minute with the menu shut, then
-     * start the pass again from the /ah command rather than clicking into a stale menu.
-     */
     private void startRemoveRetry() {
         closeAnyMenu();
 
@@ -1350,7 +1279,6 @@ public class IronAhRestocker extends Module {
         delayCounter = jitter(goneRetryMinutes.get() * 60 * 20, 20 * 10);
         state = State.REMOVE_RETRY;
 
-        // worded so it matches neither gone-message nor limit-message, or the module answers itself
         if (notifications.get()) info("Pausing about %d minute(s), then trying the pickup again.", goneRetryMinutes.get());
     }
 
@@ -1379,14 +1307,10 @@ public class IronAhRestocker extends Module {
         state = State.REMOVE_CLOSE;
     }
 
-    // ---------------------------------------------------------------- shared
-
-    /** Normal end of a restock run. Straight back round after a short randomised gap. */
     private void endCycle(boolean failed) {
         lastCycleFailed = failed;
         cyclesSinceClear++;
 
-        // scheduled clearing. the limit message sets this flag too, from startLimitCooldown
         if (clearDue()) pendingRemoval = true;
 
         closeAnyMenu();
@@ -1394,10 +1318,6 @@ public class IronAhRestocker extends Module {
         state = State.COOLDOWN;
     }
 
-    /**
-     * Whether a clearing pass is due now. OnlyWhenFull never schedules one here, it waits for the
-     * server to say the ah is full, which is what sets pendingRemoval from startLimitCooldown.
-     */
     private boolean clearDue() {
         if (!removeListings.get()) return false;
 
@@ -1408,14 +1328,12 @@ public class IronAhRestocker extends Module {
         };
     }
 
-    /** Cycle that did no work. Longer, still randomised, so an empty chest does not spam commands. */
     private void endCycleBackoff() {
         closeAnyMenu();
         delayCounter = jitter(idleBackoff.get(), 40);
         state = State.COOLDOWN;
     }
 
-    /** The one thing that actually parks the module: the server saying we listed too much. */
     private void startLimitCooldown() {
         lastCycleFailed = true;
         pendingRemoval = true;
@@ -1423,7 +1341,6 @@ public class IronAhRestocker extends Module {
         delayCounter = jitter(cycleCooldownSeconds.get() * 20, 20 * 10);
         state = State.COOLDOWN;
 
-        // deliberately worded so it cannot match limit-message and re-enter the chat handler
         if (notifications.get()) info("Parking for about %d seconds.", cycleCooldownSeconds.get());
     }
 
@@ -1462,21 +1379,15 @@ public class IronAhRestocker extends Module {
     private void onChatMessage(ReceiveMessageEvent event) {
         if (!isActive()) return;
 
-        // already parked, nothing left for this message to trigger
         if (state == State.COOLDOWN) return;
 
-        // our own chat output comes straight back through this handler. without this guard the
-        // module answers itself, every reply spawning more replies, until the client drowns
         if (handlingMessage) return;
 
         String msg = event.getMessage().getString();
         if (msg == null || msg.isEmpty()) return;
 
-        // anything Meteor printed is client side, never the server talking
         if (msg.contains("[Meteor]")) return;
 
-        // a listing sold out from under the pickup. REMOVE_RETRY is left out on purpose: more of
-        // these arriving during the pause must not keep pushing the timer back
         if (inRemovalPickup() && matchesGoneMessage(msg)) {
             handlingMessage = true;
             try {
@@ -1497,13 +1408,11 @@ public class IronAhRestocker extends Module {
         }
     }
 
-    /** Only the states that actually click listings out of the ah listen for a gone message. */
     private boolean inRemovalPickup() {
         return state == State.REMOVE_SEND || state == State.REMOVE_OPEN_MINE
             || state == State.REMOVE_MINE_WAIT || state == State.REMOVE_CLICK;
     }
 
-    /** Matches "that was already bought" and its many wordings. */
     private boolean matchesGoneMessage(String msg) {
         try {
             return Pattern.compile(goneRegex.get(), Pattern.CASE_INSENSITIVE).matcher(msg).find();
@@ -1519,12 +1428,10 @@ public class IronAhRestocker extends Module {
         EveryNCycles
     }
 
-    /** Matches the limit warning in whatever wording the server uses. */
     private boolean matchesLimitMessage(String msg) {
         try {
             return Pattern.compile(limitRegex.get(), Pattern.CASE_INSENSITIVE).matcher(msg).find();
         } catch (Exception e) {
-            // a broken regex must not silently disable the one guard that matters
             String lower = msg.toLowerCase(Locale.ROOT);
             return lower.contains("too many") || lower.contains("limit");
         }

--- a/src/main/java/com/nnpg/glazed/modules/main/SlabCrafter.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/SlabCrafter.java
@@ -26,23 +26,11 @@ import net.minecraft.world.phys.Vec3;
 
 import java.util.Random;
 
-/**
- * Pulls logs out of the /orders storage and turns them into slabs on the crafting table you are
- * looking at.
- *
- * One cycle: /orders, click the chest three from the end, click the first entry, click the chest in
- * the middle, shift a few stacks of logs out, then open the table and craft logs to planks and
- * planks to slabs. Looking away from the table is how you pause it.
- *
- * The menu chain is the same one Order Dropper walks, and the crafting half leans on how the
- * vanilla crafting menu routes shift clicks: from your inventory they land in the grid, and on the
- * result slot the server repeats the craft until the ingredients run out.
- */
 public class SlabCrafter extends Module {
     private static final int RESULT_SLOT = 0;
     private static final int GRID_FIRST = 1;
     private static final int GRID_LAST = 9;
-    private static final int ROW_LAST = 3;   // the slab recipe wants three planks in the top row
+    private static final int ROW_LAST = 3;
     private static final int INV_FIRST = 10;
     private static final int MENU_SLOTS = 46;
 
@@ -379,7 +367,6 @@ public class SlabCrafter extends Module {
             return;
         }
 
-        // a table that never finishes is worse than one that gives up, so put a ceiling on it
         if (isCrafting() && ++craftTicks > craftWatchdog.get()) {
             if (notifications.get()) warning("Crafting is taking far too long, backing off.");
             endCycleBackoff();
@@ -416,13 +403,10 @@ public class SlabCrafter extends Module {
         }
     }
 
-    // ---------------------------------------------------------------- cycle start
-
     private void tickIdle() {
         BlockPos target = resolveTable(true);
 
         if (target == null) {
-            // say so. a module that waits without a word is indistinguishable from a broken one
             announceWaiting();
             delayCounter = jitter(12, 4);
             return;
@@ -439,7 +423,6 @@ public class SlabCrafter extends Module {
             return;
         }
 
-        // one stack of logs becomes roughly eight of slabs, so nine free slots buys one stack
         targetStacks = Math.max(1, Math.min(logStacks.get(), free / 9));
 
         if (!fetchLogs.get() || countLogs() >= targetStacks * 64) {
@@ -450,7 +433,6 @@ public class SlabCrafter extends Module {
         state = State.ORDERS_SEND;
     }
 
-    /** The crafting table the crosshair is on, or null. */
     private BlockPos lookedAtTable() {
         if (!(mc.hitResult instanceof BlockHitResult hit)) return null;
         if (hit.getType() != HitResult.Type.BLOCK) return null;
@@ -458,16 +440,11 @@ public class SlabCrafter extends Module {
         return isTable(hit.getBlockPos()) ? hit.getBlockPos() : null;
     }
 
-    /** Identity first: the block a server hands you is the real one whatever class it maps to. */
     private boolean isTable(BlockPos pos) {
         Block block = mc.level.getBlockState(pos).getBlock();
         return block == Blocks.CRAFTING_TABLE || block instanceof CraftingTableBlock;
     }
 
-    /**
-     * The table to work at. The crosshair wins, and starting a cycle needs it. Once a cycle is
-     * under way the table has not moved, so a wobble mid run does not throw away the trip.
-     */
     private BlockPos resolveTable(boolean starting) {
         BlockPos looked = lookedAtTable();
         if (looked != null) return looked;
@@ -503,7 +480,6 @@ public class SlabCrafter extends Module {
         return best;
     }
 
-    /** Every few seconds, and named: knowing what the crosshair is on is the whole answer. */
     private void announceWaiting() {
         if (!notifications.get()) return;
         if (idleNags++ % 8 != 0) return;
@@ -516,8 +492,6 @@ public class SlabCrafter extends Module {
 
         info("Waiting: point your crosshair at a crafting table.");
     }
-
-    // ---------------------------------------------------------------- the orders menus
 
     private void tickOrdersSend() {
         markMenu();
@@ -541,7 +515,6 @@ public class SlabCrafter extends Module {
         }
     }
 
-    /** The chest three from the end of the orders menu, the same one Order Dropper clicks. */
     private void tickOrdersClick() {
         ChestMenu menu = GlazedShop.openContainer();
 
@@ -603,7 +576,6 @@ public class SlabCrafter extends Module {
         clickMenu(menu, slot, State.LOGS_WAIT);
     }
 
-    /** Shared wait: a menu counts as new when the id changes, or when the contents do. */
     private void tickMenuWait(State next, String what) {
         ChestMenu menu = GlazedShop.openContainer();
 
@@ -620,8 +592,6 @@ public class SlabCrafter extends Module {
             endCycleBackoff();
         }
     }
-
-    // ---------------------------------------------------------------- taking the logs
 
     private void tickTake() {
         ChestMenu menu = GlazedShop.openContainer();
@@ -661,15 +631,9 @@ public class SlabCrafter extends Module {
         state = State.TAKE_SETTLE;
     }
 
-    /**
-     * Server menus answer clicks a tick or two later and resync whatever they refuse, so what
-     * landed in the inventory is the only honest measure of whether that click did anything.
-     */
     private void tickTakeSettle() {
         ChestMenu menu = GlazedShop.openContainer();
 
-        // a plain click can leave the stack on the cursor. put it straight back, a menu closed on
-        // a held stack throws it on the floor
         if (menu != null && !menu.getCarried().isEmpty() && takeSource >= 0) {
             mc.gameMode.handleContainerInput(menu.containerId, takeSource, 0, ContainerInput.PICKUP, mc.player);
             delayCounter = takeDelay();
@@ -686,7 +650,6 @@ public class SlabCrafter extends Module {
 
         stalled++;
 
-        // the server ignored a shift click twice, so try it the other way before giving up
         if (takeMode.get() == TakeMode.Auto && !plainClick && stalled >= 2) {
             plainClick = true;
             stalled = 0;
@@ -718,7 +681,6 @@ public class SlabCrafter extends Module {
         delayCounter = jitter(screenDelay.get(), 2);
 
         if (countLogs() <= 0) {
-            // nothing came out, do not come straight back and re-run the command
             endCycleBackoff();
             return;
         }
@@ -726,8 +688,6 @@ public class SlabCrafter extends Module {
         if (notifications.get()) info("Pulled %d stack(s) of logs, crafting.", grabbed);
         state = State.TABLE_OPEN;
     }
-
-    // ---------------------------------------------------------------- the crafting table
 
     private void tickTableOpen() {
         tablePos = resolveTable(false);
@@ -738,14 +698,12 @@ public class SlabCrafter extends Module {
             return;
         }
 
-        // the real hit when the crosshair is still on it, otherwise aim at the middle of the block
         BlockHitResult hit = mc.hitResult instanceof BlockHitResult looked
             && looked.getType() == HitResult.Type.BLOCK
             && looked.getBlockPos().equals(tablePos)
                 ? looked
                 : new BlockHitResult(Vec3.atCenterOf(tablePos), Direction.UP, tablePos, false);
 
-        // the same call a right click makes, swing included
         mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, hit);
         mc.player.swing(InteractionHand.MAIN_HAND);
 
@@ -791,10 +749,6 @@ public class SlabCrafter extends Module {
         return menu.slots.size() >= MENU_SLOTS ? menu : null;
     }
 
-    /**
-     * Logs to planks. One log type at a time: the recipe takes a single ingredient, so a second
-     * kind of log in the grid would just stop it matching.
-     */
     private void tickPlanksPlace() {
         CraftingMenu menu = craftingMenu();
 
@@ -813,7 +767,6 @@ public class SlabCrafter extends Module {
             return;
         }
 
-        // grid has to hold nothing but the logs in the first slot
         if (tidyGrid(menu, GRID_FIRST, this::isLog)) return;
 
         if (!itemAt(menu, GRID_FIRST).isEmpty()) {
@@ -830,7 +783,6 @@ public class SlabCrafter extends Module {
             return;
         }
 
-        // from the inventory a shift click lands in the grid, nowhere else
         mc.gameMode.handleContainerInput(menu.containerId, source, 0, ContainerInput.QUICK_MOVE, mc.player);
 
         waited = 0;
@@ -869,17 +821,12 @@ public class SlabCrafter extends Module {
         craftSnapshot = countLogs();
         outputSnapshot = countPlanks();
 
-        // on the result slot the server repeats the craft until the logs run out or you fill up
         mc.gameMode.handleContainerInput(menu.containerId, RESULT_SLOT, 0, ContainerInput.QUICK_MOVE, mc.player);
 
         delayCounter = jitter(craftDelay.get(), 2);
         state = State.PLANKS_PLACE;
     }
 
-    /**
-     * Planks to slabs. Three of one kind in the top row, so it works a single plank type at a
-     * time and splits the last stack across the row rather than leaving it behind.
-     */
     private void tickSlabsFill() {
         CraftingMenu menu = craftingMenu();
 
@@ -906,7 +853,6 @@ public class SlabCrafter extends Module {
             }
         }
 
-        // only the row, and only this plank type. anything else goes back to the inventory
         if (tidyGrid(menu, ROW_LAST, stack -> stack.is(plankType))) return;
 
         if (rowFilled(menu)) {
@@ -923,13 +869,11 @@ public class SlabCrafter extends Module {
             return;
         }
 
-        // nothing left to shift in, so halve what is already there into the empty slot
         if (splitIntoRow(menu)) {
             delayCounter = jitter(craftDelay.get(), 2);
             return;
         }
 
-        // this type cannot fill a row any more, hand the leftovers back and try the next one
         if (tidyGrid(menu, 0, stack -> false)) return;
 
         plankType = null;
@@ -973,10 +917,6 @@ public class SlabCrafter extends Module {
         state = State.SLABS_FILL;
     }
 
-    /**
-     * Throws the finished slabs on the floor, a stack a click. In an open menu that is what Q on a
-     * slot does, so it goes out as one throw packet rather than a swap into the hotbar.
-     */
     private void tickDrop() {
         CraftingMenu menu = craftingMenu();
 
@@ -997,7 +937,6 @@ public class SlabCrafter extends Module {
 
         ItemStack stack = itemAt(menu, slot);
 
-        // same slot, same count, over and over means the server is refusing it
         if (slot == dropSlot && stack.getCount() == dropCount) {
             if (++dropTries >= 5) {
                 if (notifications.get()) warning("Slabs will not drop, closing the table.");
@@ -1011,7 +950,6 @@ public class SlabCrafter extends Module {
             dropped++;
         }
 
-        // button 1 throws the whole stack, button 0 would be one item at a time
         mc.gameMode.handleContainerInput(menu.containerId, slot, 1, ContainerInput.THROW, mc.player);
 
         delayCounter = dropDelay();
@@ -1024,7 +962,6 @@ public class SlabCrafter extends Module {
     private void tickTableClose() {
         CraftingMenu menu = craftingMenu();
 
-        // never close on a held stack or a loaded grid, that is how items end up on the floor
         if (menu != null) {
             if (dropCarried(menu)) return;
             if (tidyGrid(menu, 0, stack -> false)) return;
@@ -1042,14 +979,6 @@ public class SlabCrafter extends Module {
         endCycleBackoff();
     }
 
-    // ---------------------------------------------------------------- crafting helpers
-
-    /**
-     * Returns items the grid should not be holding, one stack a tick. True means it did something
-     * and the caller should let the next tick pick up where this left off.
-     *
-     * @param keepUntil grid slots below this are allowed to keep matching stacks
-     */
     private boolean tidyGrid(CraftingMenu menu, int keepUntil, java.util.function.Predicate<ItemStack> keep) {
         for (int slot = GRID_FIRST; slot <= GRID_LAST; slot++) {
             ItemStack stack = itemAt(menu, slot);
@@ -1057,7 +986,6 @@ public class SlabCrafter extends Module {
             if (stack.isEmpty()) continue;
             if (slot <= keepUntil && keep.test(stack)) continue;
 
-            // same slot, same count, over and over means the server is refusing it
             if (slot == tidySlot && stack.getCount() == tidyCount) {
                 if (++tidyTries >= 5) {
                     if (notifications.get()) warning("The grid will not empty, closing the table.");
@@ -1082,7 +1010,6 @@ public class SlabCrafter extends Module {
         return false;
     }
 
-    /** All three row slots loaded, which is what the slab recipe wants. */
     private boolean rowFilled(CraftingMenu menu) {
         for (int slot = GRID_FIRST; slot <= ROW_LAST; slot++) {
             if (itemAt(menu, slot).isEmpty()) return false;
@@ -1091,11 +1018,6 @@ public class SlabCrafter extends Module {
         return true;
     }
 
-    /**
-     * Right click takes half a stack, left click puts it down, both in the same tick so the cursor
-     * is never left holding anything across a menu close. Repeated, this walks 64 planks down to
-     * a full row instead of stranding them.
-     */
     private boolean splitIntoRow(CraftingMenu menu) {
         int empty = -1;
         int fullest = -1;
@@ -1125,7 +1047,6 @@ public class SlabCrafter extends Module {
         return true;
     }
 
-    /** Safety net: anything left on the cursor goes back where it came from before we move on. */
     private boolean dropCarried(CraftingMenu menu) {
         if (menu.getCarried().isEmpty()) {
             carrySource = -1;
@@ -1134,7 +1055,6 @@ public class SlabCrafter extends Module {
         }
 
         if (++carryTries > 3) {
-            // closing hands it back rather than leaving us clicking at a slot that will not take it
             if (notifications.get()) warning("Could not put a held stack down, closing the table.");
             endCycleBackoff();
             return true;
@@ -1150,17 +1070,12 @@ public class SlabCrafter extends Module {
         return true;
     }
 
-    /**
-     * Did the last shift click on the result actually consume anything? A full inventory is the
-     * usual reason it did not, and without this check the module would happily click forever.
-     */
     private void checkCraftProgress(boolean slabsPhase) {
         if (craftSnapshot < 0) return;
 
         int inputNow = slabsPhase ? countPlanks() : countLogs();
         int outputNow = slabsPhase ? countSlabs() : countPlanks();
 
-        // one shift click on the result is many crafts, so count what arrived, not the stack size
         if (outputNow > outputSnapshot) {
             if (slabsPhase) madeSlabs += outputNow - outputSnapshot;
             else madePlanks += outputNow - outputSnapshot;
@@ -1177,7 +1092,6 @@ public class SlabCrafter extends Module {
         outputSnapshot = -1;
     }
 
-    /** The plank type with the most in the inventory, as long as there are three of them. */
     private Item bestPlank(CraftingMenu menu) {
         Item best = null;
         int bestCount = 0;
@@ -1205,8 +1119,6 @@ public class SlabCrafter extends Module {
         return best;
     }
 
-    // ---------------------------------------------------------------- menu helpers
-
     private void clickMenu(ChestMenu menu, int slot, State next) {
         markMenu();
         mc.gameMode.handleContainerInput(menu.containerId, slot, 0, ContainerInput.PICKUP, mc.player);
@@ -1216,7 +1128,6 @@ public class SlabCrafter extends Module {
         state = next;
     }
 
-    /** Snapshot of the open menu, so the next state can tell when the server swapped it out. */
     private void markMenu() {
         ChestMenu menu = GlazedShop.openContainer();
 
@@ -1230,7 +1141,6 @@ public class SlabCrafter extends Module {
         lastSignature = signature(menu);
     }
 
-    /** Some menus swap for a fresh id, others repaint in place, so watch for either. */
     private boolean isNewMenu(ChestMenu menu) {
         if (menu.containerId != lastMenuId) return true;
         return signature(menu) != lastSignature;
@@ -1273,7 +1183,6 @@ public class SlabCrafter extends Module {
         return -1;
     }
 
-    /** The chest closest to the centre of the menu, unless the configured slot already is one. */
     private int chestNearMiddle(ChestMenu menu) {
         int total = containerSlots(menu);
         int wanted = storageSlot.get();
@@ -1326,7 +1235,6 @@ public class SlabCrafter extends Module {
             || stack.is(Items.ENDER_CHEST) || stack.is(Items.BARREL);
     }
 
-    /** Every log, stripped log, wood and hyphae, crimson and warped stems included. */
     private boolean isLog(ItemStack stack) {
         return !stack.isEmpty() && stack.is(ItemTags.LOGS);
     }
@@ -1374,9 +1282,6 @@ public class SlabCrafter extends Module {
         return free;
     }
 
-    // ---------------------------------------------------------------- timing
-
-    /** Fresh number per click, so emptying an order has no fixed rhythm. */
     private int dropDelay() {
         return randomBetween(dropDelayMin.get(), dropDelayMax.get());
     }
@@ -1398,7 +1303,6 @@ public class SlabCrafter extends Module {
         state = State.COOLDOWN;
     }
 
-    /** Cycle that did no work. Longer, still randomised, so a dry order does not spam commands. */
     private void endCycleBackoff() {
         closeAnyMenu();
         delayCounter = jitter(idleBackoff.get(), 40);

--- a/src/main/java/com/nnpg/glazed/modules/main/SlabSeller.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/SlabSeller.java
@@ -23,13 +23,6 @@ import net.minecraft.world.phys.HitResult;
 
 import java.util.Random;
 
-/**
- * Sells slabs through /sell instead of the auction house.
- *
- * One cycle: fill up out of the chest you are looking at, run /sell, shift the slabs into the
- * chest that opens, click the confirm pane, then go back for more. The confirm click sells but
- * leaves the menu open, so the module closes it itself once the chest has actually emptied.
- */
 public class SlabSeller extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgSell = settings.createGroup("Sell menu");
@@ -240,13 +233,10 @@ public class SlabSeller extends Module {
         }
     }
 
-    // ---------------------------------------------------------------- cycle start
-
     private void tickIdle() {
         BlockPos target = lookedAtChest();
 
         if (requireChestLook.get() && target == null) {
-            // waiting, silently. looking away is how you pause this thing
             delayCounter = jitter(12, 4);
             return;
         }
@@ -258,7 +248,6 @@ public class SlabSeller extends Module {
         state = State.CHEST_OPEN;
     }
 
-    /** The chest the crosshair is on, or null. */
     private BlockPos lookedAtChest() {
         if (!(mc.hitResult instanceof BlockHitResult hit)) return null;
         if (hit.getType() != HitResult.Type.BLOCK) return null;
@@ -270,8 +259,6 @@ public class SlabSeller extends Module {
 
         return null;
     }
-
-    // ---------------------------------------------------------------- filling up
 
     private void tickChestOpen() {
         BlockPos target = lookedAtChest();
@@ -290,7 +277,6 @@ public class SlabSeller extends Module {
             return;
         }
 
-        // the same call a right click makes, swing included
         mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, hit);
         mc.player.swing(InteractionHand.MAIN_HAND);
 
@@ -317,7 +303,6 @@ public class SlabSeller extends Module {
         return mc.player.containerMenu instanceof ChestMenu menu ? menu : null;
     }
 
-    /** Shift-clicks slabs out of the chest until the inventory has no room left. */
     private void tickGrab() {
         ChestMenu menu = openChest();
 
@@ -327,7 +312,6 @@ public class SlabSeller extends Module {
         }
 
         if (firstEmptyPlayerSlot(menu) < 0) {
-            // inventory is full, that is the load
             state = State.CHEST_CLOSE;
             return;
         }
@@ -362,7 +346,6 @@ public class SlabSeller extends Module {
         delayCounter = jitter(screenDelay.get(), 1);
 
         if (countInInventory() <= 0) {
-            // nothing to sell, do not come straight back and re-run the command
             endCycleBackoff();
             return;
         }
@@ -371,9 +354,6 @@ public class SlabSeller extends Module {
         state = State.SELL_OPEN;
     }
 
-    // ---------------------------------------------------------------- the sell menu
-
-    /** Same entry point Auto Sell uses, so the command goes out exactly the way that one does. */
     private void tickSellOpen() {
         GlazedSell.openSell();
         filled = 0;
@@ -383,11 +363,6 @@ public class SlabSeller extends Module {
         state = State.SELL_WAIT;
     }
 
-    /**
-     * Any chest that opens after the source chest was shut is the sell menu. An earlier version
-     * insisted on finding a green pane first and rejected the real menu, which is why this now
-     * leans on GlazedSell rather than guessing at the layout.
-     */
     private void tickSellWait() {
         if (GlazedSell.container() != null) {
             stalled = 0;
@@ -401,7 +376,6 @@ public class SlabSeller extends Module {
         }
     }
 
-    /** Shift-clicks slabs in, top rows only. The bottom row is the buttons. */
     private void tickFill() {
         ChestMenu menu = GlazedSell.container();
 
@@ -411,7 +385,6 @@ public class SlabSeller extends Module {
             return;
         }
 
-        // usable area full: sell this load, the rest goes in the next one
         if (GlazedSell.firstEmptyUsableSlot(menu) < 0) {
             delayCounter = jitter(confirmDelay.get(), 1);
             state = State.CONFIRM;
@@ -456,12 +429,10 @@ public class SlabSeller extends Module {
         delayCounter = jitter(clickDelay.get(), 1);
     }
 
-    /** Clicks the confirm button if there is one. Closing sells anyway, so a miss is not fatal. */
     private void tickConfirm() {
         ChestMenu menu = GlazedSell.container();
 
         if (menu == null) {
-            // server shut it for us, which on this server is itself the sale
             finishLoad();
             return;
         }
@@ -480,17 +451,12 @@ public class SlabSeller extends Module {
         state = State.SELL_CLOSE;
     }
 
-    /** Closing is what actually banks the sale, the same thing pressing E does. */
     private void tickSellClose() {
         GlazedSell.close();
         if (mc.screen != null) mc.setScreen(null);
         finishLoad();
     }
 
-    /**
-     * One chestful is done. If the inventory still holds slabs, open the menu again for the next
-     * load rather than walking back to the chest with items still in hand.
-     */
     private void finishLoad() {
         int left = countInInventory();
         sold += filled;
@@ -512,9 +478,6 @@ public class SlabSeller extends Module {
         endCycle();
     }
 
-    // ---------------------------------------------------------------- helpers
-
-    /** First slab in the menu slot range [from, to). */
     private int findSlab(ChestMenu menu, int from, int to) {
         for (int slot = from; slot < to && slot < menu.slots.size(); slot++) {
             if (isSlab(menu.getSlot(slot).getItem())) return slot;
@@ -529,10 +492,6 @@ public class SlabSeller extends Module {
         return stack.getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof SlabBlock;
     }
 
-    /**
-     * Confirm button, searched from the bottom right of the button row backwards. Restricting it
-     * to that last row means a slab in the deposit area can never be mistaken for a button.
-     */
     private int findButtonRowConfirm(ChestMenu menu) {
         int total = Math.min(GlazedSell.containerSlots(menu), menu.slots.size());
 
@@ -561,7 +520,6 @@ public class SlabSeller extends Module {
         return total;
     }
 
-    /** Fresh number per click, so emptying a chest has no fixed rhythm. */
     private int grabDelay() {
         int min = Math.max(1, grabDelayMin.get());
         int max = Math.max(min, grabDelayMax.get());
@@ -575,7 +533,6 @@ public class SlabSeller extends Module {
         state = State.COOLDOWN;
     }
 
-    /** Cycle that did no work. Longer, still randomised, so an empty chest does not spam commands. */
     private void endCycleBackoff() {
         closeAnyMenu();
         delayCounter = jitter(idleBackoff.get(), 40);

--- a/src/main/java/com/nnpg/glazed/modules/main/SlabUltimate.java
+++ b/src/main/java/com/nnpg/glazed/modules/main/SlabUltimate.java
@@ -28,34 +28,16 @@ import net.minecraft.world.phys.Vec3;
 
 import java.util.Random;
 
-/**
- * The whole slab run in one module: pull logs out of the /orders storage, craft them into slabs on
- * the crafting table you are looking at, sell the lot through /sell, then go round again.
- *
- * One cycle: /orders, click the chest three from the end, click the first entry, click the chest in
- * the middle, shift a few stacks of logs out, open the table and craft logs to planks and planks to
- * slabs, then /sell, load the chest, click the confirm pane and close it. Looking away from the
- * table is how you pause it.
- *
- * The menu chain is the same one Order Dropper walks, the crafting half leans on how the vanilla
- * crafting menu routes shift clicks (from your inventory they land in the grid, and on the result
- * slot the server repeats the craft until the ingredients run out), and the selling half is Slab
- * Seller's, through GlazedSell.
- */
 public class SlabUltimate extends Module {
     private static final int RESULT_SLOT = 0;
     private static final int GRID_FIRST = 1;
     private static final int GRID_LAST = 9;
-    private static final int ROW_LAST = 3;   // the slab recipe wants three planks in the top row
+    private static final int ROW_LAST = 3;
     private static final int INV_FIRST = 10;
     private static final int MENU_SLOTS = 46;
-    /** A slot of logs comes back as eight slots of slabs, so that is the headroom one wave needs. */
     private static final int WAVE_SLOTS = 8;
-    /** The slab recipe wants three planks in a row, so three whole stacks is one clean row. */
     private static final int ROW_STACKS = 3;
-    /** One full row craft comes back as six stacks, so that is the room it needs first. */
     private static final int ROW_OUTPUT_SLOTS = 6;
-    /** Backstop on the sell-and-return loop. Far above any real batch, low enough to end. */
     private static final int MAX_WAVES = 40;
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -410,7 +392,6 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // a table that never finishes is worse than one that gives up, so put a ceiling on it
         if (isCrafting() && ++craftTicks > craftWatchdog.get()) {
             if (notifications.get()) warning("Crafting is taking far too long, backing off.");
             endCycleBackoff();
@@ -451,12 +432,7 @@ public class SlabUltimate extends Module {
         }
     }
 
-    // ---------------------------------------------------------------- cycle start
-
     private void tickIdle() {
-        // slabs still on you from a batch that died mid-flight. selling them is the only way a full
-        // inventory ever comes back, and it has to happen before the table check or looking away
-        // once would leave the module wedged for good
         int stranded = slabSlots();
 
         if (stranded > 0) {
@@ -482,7 +458,6 @@ public class SlabUltimate extends Module {
         BlockPos target = resolveTable(true);
 
         if (target == null) {
-            // say so. a module that waits without a word is indistinguishable from a broken one
             announceWaiting();
             delayCounter = jitter(12, 4);
             return;
@@ -499,8 +474,6 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // a stack of logs becomes eight of slabs. selling between waves means only one wave has to
-        // fit at a time, so with finish-batch on the logs themselves are all the inventory holds
         targetStacks = finishBatch.get()
             ? Math.max(1, Math.min(logStacks.get(), free - WAVE_SLOTS))
             : Math.max(1, Math.min(logStacks.get(), free / 9));
@@ -513,7 +486,6 @@ public class SlabUltimate extends Module {
         state = State.ORDERS_SEND;
     }
 
-    /** The crafting table the crosshair is on, or null. */
     private BlockPos lookedAtTable() {
         if (!(mc.hitResult instanceof BlockHitResult hit)) return null;
         if (hit.getType() != HitResult.Type.BLOCK) return null;
@@ -521,16 +493,11 @@ public class SlabUltimate extends Module {
         return isTable(hit.getBlockPos()) ? hit.getBlockPos() : null;
     }
 
-    /** Identity first: the block a server hands you is the real one whatever class it maps to. */
     private boolean isTable(BlockPos pos) {
         Block block = mc.level.getBlockState(pos).getBlock();
         return block == Blocks.CRAFTING_TABLE || block instanceof CraftingTableBlock;
     }
 
-    /**
-     * The table to work at. The crosshair wins, and starting a cycle needs it. Once a cycle is
-     * under way the table has not moved, so a wobble mid run does not throw away the trip.
-     */
     private BlockPos resolveTable(boolean starting) {
         BlockPos looked = lookedAtTable();
         if (looked != null) return looked;
@@ -566,7 +533,6 @@ public class SlabUltimate extends Module {
         return best;
     }
 
-    /** Every few seconds, and named: knowing what the crosshair is on is the whole answer. */
     private void announceWaiting() {
         if (!notifications.get()) return;
         if (idleNags++ % 8 != 0) return;
@@ -579,8 +545,6 @@ public class SlabUltimate extends Module {
 
         info("Waiting: point your crosshair at a crafting table.");
     }
-
-    // ---------------------------------------------------------------- the orders menus
 
     private void tickOrdersSend() {
         markMenu();
@@ -604,7 +568,6 @@ public class SlabUltimate extends Module {
         }
     }
 
-    /** The chest three from the end of the orders menu, the same one Order Dropper clicks. */
     private void tickOrdersClick() {
         ChestMenu menu = GlazedShop.openContainer();
 
@@ -666,7 +629,6 @@ public class SlabUltimate extends Module {
         clickMenu(menu, slot, State.LOGS_WAIT);
     }
 
-    /** Shared wait: a menu counts as new when the id changes, or when the contents do. */
     private void tickMenuWait(State next, String what) {
         ChestMenu menu = GlazedShop.openContainer();
 
@@ -683,8 +645,6 @@ public class SlabUltimate extends Module {
             endCycleBackoff();
         }
     }
-
-    // ---------------------------------------------------------------- taking the logs
 
     private void tickTake() {
         ChestMenu menu = GlazedShop.openContainer();
@@ -724,15 +684,9 @@ public class SlabUltimate extends Module {
         state = State.TAKE_SETTLE;
     }
 
-    /**
-     * Server menus answer clicks a tick or two later and resync whatever they refuse, so what
-     * landed in the inventory is the only honest measure of whether that click did anything.
-     */
     private void tickTakeSettle() {
         ChestMenu menu = GlazedShop.openContainer();
 
-        // a plain click can leave the stack on the cursor. put it straight back, a menu closed on
-        // a held stack throws it on the floor
         if (menu != null && !menu.getCarried().isEmpty() && takeSource >= 0) {
             mc.gameMode.handleContainerInput(menu.containerId, takeSource, 0, ContainerInput.PICKUP, mc.player);
             delayCounter = takeDelay();
@@ -749,7 +703,6 @@ public class SlabUltimate extends Module {
 
         stalled++;
 
-        // the server ignored a shift click twice, so try it the other way before giving up
         if (takeMode.get() == TakeMode.Auto && !plainClick && stalled >= 2) {
             plainClick = true;
             stalled = 0;
@@ -781,7 +734,6 @@ public class SlabUltimate extends Module {
         delayCounter = jitter(screenDelay.get(), 2);
 
         if (countLogs() <= 0) {
-            // nothing came out, do not come straight back and re-run the command
             endCycleBackoff();
             return;
         }
@@ -789,8 +741,6 @@ public class SlabUltimate extends Module {
         if (notifications.get()) info("Pulled %d stack(s) of logs, crafting.", grabbed);
         state = State.TABLE_OPEN;
     }
-
-    // ---------------------------------------------------------------- the crafting table
 
     private void tickTableOpen() {
         tablePos = resolveTable(false);
@@ -801,14 +751,12 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // the real hit when the crosshair is still on it, otherwise aim at the middle of the block
         BlockHitResult hit = mc.hitResult instanceof BlockHitResult looked
             && looked.getType() == HitResult.Type.BLOCK
             && looked.getBlockPos().equals(tablePos)
                 ? looked
                 : new BlockHitResult(Vec3.atCenterOf(tablePos), Direction.UP, tablePos, false);
 
-        // the same call a right click makes, swing included
         mc.gameMode.useItemOn(mc.player, InteractionHand.MAIN_HAND, hit);
         mc.player.swing(InteractionHand.MAIN_HAND);
 
@@ -856,10 +804,6 @@ public class SlabUltimate extends Module {
         return menu.slots.size() >= MENU_SLOTS ? menu : null;
     }
 
-    /**
-     * Logs to planks. One log type at a time: the recipe takes a single ingredient, so a second
-     * kind of log in the grid would just stop it matching.
-     */
     private void tickPlanksPlace() {
         CraftingMenu menu = craftingMenu();
 
@@ -886,9 +830,6 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // the plank recipe is shapeless and takes a single ingredient, so it wants exactly one
-        // occupied grid slot and does not care which one. pinning it to the first slot is what made
-        // a stack the server dropped anywhere else bounce straight back out, over and over
         int gridLog = findItem(menu, GRID_FIRST, GRID_LAST + 1, this::isLog);
 
         if (tidyGrid(menu, 0, stack -> false, gridLog)) return;
@@ -899,9 +840,6 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // every whole stack of planks on you needs one more free slot to finish becoming slabs,
-        // and converting one more log stack adds four of them. running past that is what buried a
-        // whole run in planks it had no room left to craft, so only carry on while the pile fits
         int freeNow = freeSlots();
         int pile = wholePlankStacks();
 
@@ -911,7 +849,6 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // and never take on another four stacks of planks without somewhere to put them
         if (freeNow < 5) {
             stalled = 0;
             state = craftSlabs.get() ? State.SLABS_FILL : State.TABLE_CLOSE;
@@ -926,7 +863,6 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // from the inventory a shift click lands in the grid, nowhere else
         mc.gameMode.handleContainerInput(menu.containerId, source, 0, ContainerInput.QUICK_MOVE, mc.player);
 
         waited = 0;
@@ -965,17 +901,12 @@ public class SlabUltimate extends Module {
         craftSnapshot = menuCount(menu, this::isLog);
         outputSnapshot = menuCount(menu, this::isPlank);
 
-        // on the result slot the server repeats the craft until the logs run out or you fill up
         mc.gameMode.handleContainerInput(menu.containerId, RESULT_SLOT, 0, ContainerInput.QUICK_MOVE, mc.player);
 
         delayCounter = jitter(craftDelay.get(), 2);
         state = State.PLANKS_PLACE;
     }
 
-    /**
-     * Planks to slabs. Three of one kind in the top row, so it works a single plank type at a
-     * time and splits the last stack across the row rather than leaving it behind.
-     */
     private void tickSlabsFill() {
         CraftingMenu menu = craftingMenu();
 
@@ -1009,7 +940,6 @@ public class SlabUltimate extends Module {
             }
         }
 
-        // only the row, and only this plank type. anything else goes back to the inventory
         if (tidyGrid(menu, ROW_LAST, stack -> stack.is(plankType))) return;
 
         if (rowFilled(menu)) {
@@ -1018,17 +948,12 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // a full row comes back as six stacks. starting one without room for all of it strands the
-        // ingredients in a grid that then cannot be emptied, which is items on the floor
         if (freeSlots() < ROW_OUTPUT_SLOTS) {
             if (notifications.get()) info("No room for another craft, selling what is made.");
             state = State.TABLE_CLOSE;
             return;
         }
 
-        // a row is three whole stacks, counting what is already in it. starting one this type
-        // cannot finish just shifts stacks in and straight back out again, which is the couple of
-        // seconds of shuffling at the tail of every run
         if (fullStacksOnly.get() && rowLoaded(menu) + wholeStacksOf(menu, plankType) < ROW_STACKS) {
             if (tidyGrid(menu, 0, stack -> false)) return;
 
@@ -1046,14 +971,11 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // nothing whole left to shift in. splitting would put an odd count in the row and hand the
-        // change back as a part stack, so on full-stacks-only this type is simply finished
         if (!fullStacksOnly.get() && splitIntoRow(menu)) {
             delayCounter = jitter(craftDelay.get(), 2);
             return;
         }
 
-        // this type cannot fill a row any more, hand the leftovers back and try the next one
         if (tidyGrid(menu, 0, stack -> false)) return;
 
         plankType = null;
@@ -1100,7 +1022,6 @@ public class SlabUltimate extends Module {
     private void tickTableClose() {
         CraftingMenu menu = craftingMenu();
 
-        // never close on a held stack or a loaded grid, that is how items end up on the floor
         if (menu != null) {
             if (dropCarried(menu)) return;
             if (tidyGrid(menu, 0, stack -> false)) return;
@@ -1111,7 +1032,6 @@ public class SlabUltimate extends Module {
         if (notifications.get()) info("Crafted %d plank(s) and %d slab(s) this session.", madePlanks, madeSlabs);
 
         if (slabSlots() <= 0) {
-            // nothing came out of the table, do not run /sell for an empty inventory
             if (notifications.get()) warning("No slabs came out of the table, nothing to sell.");
             endCycleBackoff();
             return;
@@ -1122,9 +1042,6 @@ public class SlabUltimate extends Module {
         state = State.SELL_OPEN;
     }
 
-    // ---------------------------------------------------------------- the sell menu
-
-    /** Same entry point Auto Sell and Slab Seller use, so the command goes out exactly as theirs does. */
     private void tickSellOpen() {
         GlazedSell.openSell();
 
@@ -1136,7 +1053,6 @@ public class SlabUltimate extends Module {
         state = State.SELL_WAIT;
     }
 
-    /** Any chest that opens once the table is shut is the sell menu. */
     private void tickSellWait() {
         if (GlazedSell.container() != null) {
             stalled = 0;
@@ -1150,7 +1066,6 @@ public class SlabUltimate extends Module {
         }
     }
 
-    /** Shift clicks slabs in, top rows only. The bottom row is the buttons. */
     private void tickFill() {
         ChestMenu menu = GlazedSell.container();
 
@@ -1160,7 +1075,6 @@ public class SlabUltimate extends Module {
             return;
         }
 
-        // usable area full: sell this load, the rest goes in the next one
         if (GlazedSell.firstEmptyUsableSlot(menu) < 0) {
             delayCounter = jitter(confirmDelay.get(), 1);
             state = State.CONFIRM;
@@ -1205,12 +1119,10 @@ public class SlabUltimate extends Module {
         delayCounter = jitter(fillDelay.get(), 1);
     }
 
-    /** Clicks the green pane if there is one. Closing sells anyway, so a miss is not fatal. */
     private void tickConfirm() {
         ChestMenu menu = GlazedSell.container();
 
         if (menu == null) {
-            // server shut it for us, which on this server is itself the sale
             finishLoad();
             return;
         }
@@ -1229,17 +1141,12 @@ public class SlabUltimate extends Module {
         state = State.SELL_CLOSE;
     }
 
-    /** Leaving the menu is what banks the sale, the same thing pressing E does. */
     private void tickSellClose() {
         GlazedSell.close();
         if (mc.screen != null) mc.setScreen(null);
         finishLoad();
     }
 
-    /**
-     * One chestful done. If slabs are still on you, open /sell again for the next load rather than
-     * going back for logs with items in hand.
-     */
     private void finishLoad() {
         int left = slabSlots();
         sold += filled;
@@ -1258,8 +1165,6 @@ public class SlabUltimate extends Module {
             info("Sold %d stack(s), %d this session.", filled, sold);
         }
 
-        // logs or whole stacks of planks still on you means the batch is not done, and going back
-        // for more logs now is exactly what strands them. reopen the table and finish the job
         if (finishBatch.get() && moreToCraft()) {
             if (++waves > MAX_WAVES) {
                 if (notifications.get()) warning("Hit the %d wave limit with %d log(s) and %d plank(s) left, ending the batch.", MAX_WAVES, countLogs(), countPlanks());
@@ -1283,10 +1188,6 @@ public class SlabUltimate extends Module {
         endCycle();
     }
 
-    /**
-     * Confirm button, searched from the bottom right of the button row backwards. Restricting it to
-     * that last row means a slab in the deposit area can never be mistaken for a button.
-     */
     private int findButtonRowConfirm(ChestMenu menu) {
         int total = Math.min(GlazedSell.containerSlots(menu), menu.slots.size());
 
@@ -1297,7 +1198,6 @@ public class SlabUltimate extends Module {
         return -1;
     }
 
-    /** Slots holding slabs, which is what the sell chest is filled by. */
     private int slabSlots() {
         int total = 0;
         int size = mc.player.getInventory().getContainerSize();
@@ -1314,19 +1214,10 @@ public class SlabUltimate extends Module {
         endCycleBackoff();
     }
 
-    // ---------------------------------------------------------------- crafting helpers
-
-    /**
-     * Returns items the grid should not be holding, one stack a tick. True means it did something
-     * and the caller should let the next tick pick up where this left off.
-     *
-     * @param keepUntil grid slots below this are allowed to keep matching stacks
-     */
     private boolean tidyGrid(CraftingMenu menu, int keepUntil, java.util.function.Predicate<ItemStack> keep) {
         return tidyGrid(menu, keepUntil, keep, -1);
     }
 
-    /** @param keepSlot one grid slot to leave alone whatever is in it, or -1 for none */
     private boolean tidyGrid(CraftingMenu menu, int keepUntil, java.util.function.Predicate<ItemStack> keep, int keepSlot) {
         for (int slot = GRID_FIRST; slot <= GRID_LAST; slot++) {
             ItemStack stack = itemAt(menu, slot);
@@ -1335,8 +1226,6 @@ public class SlabUltimate extends Module {
             if (slot == keepSlot) continue;
             if (slot <= keepUntil && keep.test(stack)) continue;
 
-            // the whole grid unchanged, over and over, means the server is refusing it. keying
-            // this on a single slot let two stuck slots alternate and reset the counter forever
             long shape = gridShape(menu);
 
             if (shape == tidyShape) {
@@ -1361,7 +1250,6 @@ public class SlabUltimate extends Module {
         return false;
     }
 
-    /** Stock across the grid and the inventory. The result slot is only a preview, so it is skipped. */
     private int menuCount(net.minecraft.world.inventory.AbstractContainerMenu menu, java.util.function.Predicate<ItemStack> test) {
         int total = 0;
 
@@ -1373,7 +1261,6 @@ public class SlabUltimate extends Module {
         return total;
     }
 
-    /** Everything the grid holds as one number, so a change anywhere in it is visible. */
     private long gridShape(CraftingMenu menu) {
         long hash = 1;
 
@@ -1385,10 +1272,6 @@ public class SlabUltimate extends Module {
         return hash;
     }
 
-    /**
-     * Last resort against a shuffle that never crafts. Counting the grid and the inventory together
-     * means moving a stack between them is not progress, which is the whole shape of that loop.
-     */
     private boolean bouncing(CraftingMenu menu, java.util.function.Predicate<ItemStack> input) {
         int now = menuCount(menu, input);
 
@@ -1401,7 +1284,6 @@ public class SlabUltimate extends Module {
         return ++bounces > 24;
     }
 
-    /** Row slots already holding something, so a part built row still counts toward the three. */
     private int rowLoaded(CraftingMenu menu) {
         int total = 0;
 
@@ -1412,7 +1294,6 @@ public class SlabUltimate extends Module {
         return total;
     }
 
-    /** Whole stacks of one item in the inventory half of the menu. */
     private int wholeStacksOf(net.minecraft.world.inventory.AbstractContainerMenu menu, Item type) {
         int total = 0;
 
@@ -1424,7 +1305,6 @@ public class SlabUltimate extends Module {
         return total;
     }
 
-    /** All three row slots loaded, which is what the slab recipe wants. */
     private boolean rowFilled(CraftingMenu menu) {
         for (int slot = GRID_FIRST; slot <= ROW_LAST; slot++) {
             if (itemAt(menu, slot).isEmpty()) return false;
@@ -1433,11 +1313,6 @@ public class SlabUltimate extends Module {
         return true;
     }
 
-    /**
-     * Right click takes half a stack, left click puts it down, both in the same tick so the cursor
-     * is never left holding anything across a menu close. Repeated, this walks 64 planks down to
-     * a full row instead of stranding them.
-     */
     private boolean splitIntoRow(CraftingMenu menu) {
         int empty = -1;
         int fullest = -1;
@@ -1467,7 +1342,6 @@ public class SlabUltimate extends Module {
         return true;
     }
 
-    /** Safety net: anything left on the cursor goes back where it came from before we move on. */
     private boolean dropCarried(CraftingMenu menu) {
         if (menu.getCarried().isEmpty()) {
             carrySource = -1;
@@ -1476,7 +1350,6 @@ public class SlabUltimate extends Module {
         }
 
         if (++carryTries > 3) {
-            // closing hands it back rather than leaving us clicking at a slot that will not take it
             if (notifications.get()) warning("Could not put a held stack down, closing the table.");
             endCycleBackoff();
             return true;
@@ -1492,20 +1365,12 @@ public class SlabUltimate extends Module {
         return true;
     }
 
-    /**
-     * Did the last shift click on the result actually consume anything? A full inventory is the
-     * usual reason it did not, and without this check the module would happily click forever.
-     */
     private void checkCraftProgress(CraftingMenu menu, boolean slabsPhase) {
         if (craftSnapshot < 0) return;
 
-        // count the grid as well as the inventory. the stock sits in the grid at the moment the
-        // snapshot is taken, so an inventory-only count can never watch it be consumed and every
-        // craft reads as a stall, which is what cut each run off after three rounds
         int inputNow = slabsPhase ? menuCount(menu, this::isPlank) : menuCount(menu, this::isLog);
         int outputNow = slabsPhase ? menuCount(menu, this::isSlab) : menuCount(menu, this::isPlank);
 
-        // one shift click on the result is many crafts, so count what arrived, not the stack size
         if (outputNow > outputSnapshot) {
             if (slabsPhase) madeSlabs += outputNow - outputSnapshot;
             else madePlanks += outputNow - outputSnapshot;
@@ -1522,10 +1387,6 @@ public class SlabUltimate extends Module {
         outputSnapshot = -1;
     }
 
-    /**
-     * A stack holding as much as it can. Reads the item's own limit rather than assuming 64, so a
-     * server that shrinks a stack with a component does not quietly break the row.
-     */
     private boolean isWholeStack(ItemStack stack) {
         if (stack.isEmpty()) return false;
 
@@ -1533,7 +1394,6 @@ public class SlabUltimate extends Module {
         return stack.getCount() >= max;
     }
 
-    /** Whole stacks of the single best plank type on you. Part stacks are remainders, not stock. */
     private int wholePlankStacks() {
         java.util.Map<Item, Integer> counts = new java.util.HashMap<>();
         int size = mc.player.getInventory().getContainerSize();
@@ -1551,15 +1411,12 @@ public class SlabUltimate extends Module {
         return best;
     }
 
-    /** Anything left that is worth reopening the table for. */
     private boolean moreToCraft() {
-        // 48 logs is 192 planks, which is exactly one row, so anything less cannot make a craft
         if (countLogs() >= (fullStacksOnly.get() ? 48 : 1)) return true;
 
         return craftSlabs.get() && wholePlankStacks() >= ROW_STACKS;
     }
 
-    /** The plank type with the most in the inventory, as long as there are three of them. */
     private Item bestPlank(CraftingMenu menu) {
         Item best = null;
         int bestCount = 0;
@@ -1583,7 +1440,6 @@ public class SlabUltimate extends Module {
                 if (isWholeStack(found)) whole++;
             }
 
-            // a clean row is three whole stacks. anything short of that is a remainder, not stock
             boolean usable = fullStacksOnly.get() ? whole >= ROW_STACKS : total >= 3;
 
             if (usable && total > bestCount) {
@@ -1595,8 +1451,6 @@ public class SlabUltimate extends Module {
         return best;
     }
 
-    // ---------------------------------------------------------------- menu helpers
-
     private void clickMenu(ChestMenu menu, int slot, State next) {
         markMenu();
         mc.gameMode.handleContainerInput(menu.containerId, slot, 0, ContainerInput.PICKUP, mc.player);
@@ -1606,7 +1460,6 @@ public class SlabUltimate extends Module {
         state = next;
     }
 
-    /** Snapshot of the open menu, so the next state can tell when the server swapped it out. */
     private void markMenu() {
         ChestMenu menu = GlazedShop.openContainer();
 
@@ -1620,7 +1473,6 @@ public class SlabUltimate extends Module {
         lastSignature = signature(menu);
     }
 
-    /** Some menus swap for a fresh id, others repaint in place, so watch for either. */
     private boolean isNewMenu(ChestMenu menu) {
         if (menu.containerId != lastMenuId) return true;
         return signature(menu) != lastSignature;
@@ -1663,7 +1515,6 @@ public class SlabUltimate extends Module {
         return -1;
     }
 
-    /** The chest closest to the centre of the menu, unless the configured slot already is one. */
     private int chestNearMiddle(ChestMenu menu) {
         int total = containerSlots(menu);
         int wanted = storageSlot.get();
@@ -1716,7 +1567,6 @@ public class SlabUltimate extends Module {
             || stack.is(Items.ENDER_CHEST) || stack.is(Items.BARREL);
     }
 
-    /** Every log, stripped log, wood and hyphae, crimson and warped stems included. */
     private boolean isLog(ItemStack stack) {
         return !stack.isEmpty() && stack.is(ItemTags.LOGS);
     }
@@ -1764,9 +1614,6 @@ public class SlabUltimate extends Module {
         return free;
     }
 
-    // ---------------------------------------------------------------- timing
-
-    /** Fresh number per click, so emptying an order has no fixed rhythm. */
     private int takeDelay() {
         return randomBetween(takeDelayMin.get(), takeDelayMax.get());
     }
@@ -1784,7 +1631,6 @@ public class SlabUltimate extends Module {
         state = State.COOLDOWN;
     }
 
-    /** Cycle that did no work. Longer, still randomised, so a dry order does not spam commands. */
     private void endCycleBackoff() {
         closeAnyMenu();
         delayCounter = jitter(idleBackoff.get(), 40);


### PR DESCRIPTION
Strips every comment from the thirteen files that came in with #83 and #85 — the AH, slab and AFK automation modules and the boat and chest sellers. Code is unchanged; only comment lines and trailing comments are gone.

GlazedAddon.java is untouched, since the comments in it are not from my PRs.